### PR TITLE
Update genesis for mainnet launch

### DIFF
--- a/genesis_mainnet.yaml
+++ b/genesis_mainnet.yaml
@@ -1,29 +1,6 @@
 account:
   initBalances:
-    io12yxdwewry70gr9fs6fphyfaky9c7gurmzk8f4f: "100000000000000000000000000"
-    io14vmhs9c75r2ptxdaqrtk0dz7skct30pxmt69d9: "100000000000000000000000000"
-    io159fv8mu9d5djk8u2t0flgw4yqmt6fg98uqjka8: "100000000000000000000000000"
-    io15fqav3tugm96ge7anckx0k4gukz5m4mqf0jpv3: "100000000000000000000000000"
-    io15npzu93ug8r3zdeysppnyrcdu2xssz0lcam9l9: "100000000000000000000000000"
-    io127ftn4ry6wgxdrw4hcd6gdwqlq70ujk98dvtw5: "100000000000000000000000000"
-    io1ar5l5s268rtgzshltnqv88mua06ucm58dx678y: "100000000000000000000000000"
-    io1c3r4th3zrk4uhv83a9gr4gvn3y6pzaj6mc84ea: "100000000000000000000000000"
-    io1cup9k8hl8fp40vrj29ex8djc346780dk223end: "100000000000000000000000000"
-    io1du4eq4f88n4wyc026l3gamjwetlgsg4jz7j884: "100000000000000000000000000"
-    io1fks575kklxafq4fwjccmz5d3pmq5ynxk5h6h0v: "100000000000000000000000000"
-    io1gf08snppu2a2wfd50pjas2j6q2kcxjzqph3pep: "100000000000000000000000000"
-    io1gh7xfrsnj6p5uqgjpk9xq6jg9na28aewgp7a9v: "100000000000000000000000000"
-    io1jafqlvntcxgyp6e0uxctt3tljzc3vyv5hg4ukh: "100000000000000000000000000"
-    io1nyjs526mnqcsx4twa7nptkg08eclsw5c2dywp4: "100000000000000000000000000"
-    io1scs89jur7qklzh5vfrmha3c40u8yajjx6kvzg9: "100000000000000000000000000"
-    io1u5ff879gg2dw9vfpxr2tsmuaz07e2rea6gvl7s: "100000000000000000000000000"
-    io1v0q5g2f8z6l3v25krl677chdx7g5pwt9kvqfpc: "100000000000000000000000000"
-    io1vtm2zgn830pn6auc2cvnchgwdaefa9gr4z0s86: "100000000000000000000000000"
-    io1wv5m0xyermvr2n0wjx2cjsqwyk863drdl5qfyn: "100000000000000000000000000"
-    io1x9kjkr0qv2fa7j4t2as8lrj223xxsqt4tl7xp7: "100000000000000000000000000"
-    io1xsdegzr2hdj5sv5ad4nr0yfgpsd98e40u6svem: "100000000000000000000000000"
-    io1xsx5n94kg2zv64r7tm8vyz9mh86amfak9ka9xx: "100000000000000000000000000"
-    io1z7mjef7w528nasnsafan0rp6yuvkvq405l6r8j: "100000000000000000000000000"
+    io12yxdwewry70gr9fs6fphyfaky9c7gurmzk8f4f: "9800000000000000000000000000" # Need to update the address
 blockchain:
   actionGasLimit: 5000000
   blockGasLimit: 20000000
@@ -37,7 +14,7 @@ poll:
   delegates: []
   enableGravityChainVoting: true
   gravityChainHeightInterval: 100
-  gravityChainStartHeight: 7502100
+  gravityChainStartHeight: 7614500
   registerContractAddress: 0xc8c2bc733bbf0935e9e9e080456661b96d7946c8
   scoreThreshold: "2000000000000000000000000"
   selfStakingThreshold: "1200000000000000000000000"
@@ -60,6 +37,11 @@ rewarding:
     - io1du4eq4f88n4wyc026l3gamjwetlgsg4jz7j884
     - io12yxdwewry70gr9fs6fphyfaky9c7gurmzk8f4f
     - io1lx53nfgq2dnzrz5ecz2ecs7vvl6qll0mkn970w
+    - io1u5xy0ecnrjrdkzyctfqh37lgr5pcfzphgqrdwt
+    - io1aj8arp07xw6s9rgh42af5xf98csyuehnnwlk52
+    - io18gdmv5g0xhkuj2cdyvp8076uwhl7h3gesmzh8u
+    - io1td5fvamm3qf22r5h93gay6ggqdh9z0edeqx63u
+    - io1qs785af9k9xf3xgd6vut7um9zcthtrvsn2xap2
     - io127ftn4ry6wgxdrw4hcd6gdwqlq70ujk98dvtw5
     - io1wv5m0xyermvr2n0wjx2cjsqwyk863drdl5qfyn
     - io1v0q5g2f8z6l3v25krl677chdx7g5pwt9kvqfpc
@@ -72,9 +54,15 @@ rewarding:
     - io1z7mjef7w528nasnsafan0rp6yuvkvq405l6r8j
     - io1cup9k8hl8fp40vrj29ex8djc346780dk223end
     - io1scs89jur7qklzh5vfrmha3c40u8yajjx6kvzg9
+    - io10kyvvzu08pjeylymq4umknjal25ea3ptfknrpf
+    - io18mvepyxkcd5jkyplfqn27ydkpsendrey3xe2l8
+    - io1nz40npqa3yvek4zdasmqaetl2j4h6urejfkera
+    - io1m7p9yrejngxyvxhvn7p9g9uwlvd7uuamg8wcjd
+    - io1cwwm08dwv9phh3wt5vsdhu9gcypw9q2sc7pl9s
+    - io14aj46jjmtt83vts9syhrs9st80czumg40cjasl
   foundationBonus: "80000000000000000000"
   foundationBonusLastEpoch: 8760
-  initBalance: "1200000000000000000000000000"
+  initBalance: "200000000000000000000000000"
   numDelegatesForEpochReward: 100
   numDelegatesForFoundationBonus: 36
   productivityThreshold: 85

--- a/genesis_mainnet.yaml
+++ b/genesis_mainnet.yaml
@@ -1,6 +1,6 @@
 account:
   initBalances:
-    io12yxdwewry70gr9fs6fphyfaky9c7gurmzk8f4f: "9800000000000000000000000000" # Need to update the address
+    io1uqhmnttmv0pg8prugxxn7d8ex9angrvfjfthxa: "9800000000000000000000000000"
 blockchain:
   actionGasLimit: 5000000
   blockGasLimit: 20000000


### PR DESCRIPTION
1. Time stamp and eth height is changed to 4/21, and estimated height around 4/21's 7pm pdt.
2. Exempt 36 robots from epoch bonus
3. Allow 200M token in the reward fund
4. Make only one address to lock 9800M token (@raullenchai , you need to provide an address here)