### PR TITLE
Use the alertmanager default email template.

### DIFF
--- a/alert/alertmanager.yml.tmpl
+++ b/alert/alertmanager.yml.tmpl
@@ -16,5 +16,4 @@ receivers:
     smarthost: '_SMTP_HOST_:_SMTP_PORT_'
     auth_username: '_EMAIL_'
     auth_password: '_PASSWORD_'
-    html: '{{ template "email.html" . }}'
     headers: { Subject: "IOTEX NODE Alert" }

--- a/scripts/setup_monitor_alert.sh
+++ b/scripts/setup_monitor_alert.sh
@@ -59,6 +59,7 @@ function check-monitor() {
 
 function make-workspace() {
     $MKDIR ${IOTEX_ALERT_HOME}/{etc,template}
+    chown 777 ${IOTEX_ALERT_HOME} -R
 }
 
 function download-files() {


### PR DESCRIPTION
Fix the send email bug. Use the prometheus official email html.