### PR TITLE
Fix the bug when run docker-compose command 

### DIFF
--- a/monitor/.env
+++ b/monitor/.env
@@ -1,4 +1,4 @@
 IOTEX_IMAGE=iotex/iotex-core
 IOTEX_HOME=~/iotex-var
-IOTEX_MONITOR_HOME=$IOTEX_HOME/monitor
+IOTEX_MONITOR_HOME=~/iotex-var/monitor
 


### PR DESCRIPTION
Fix the bug when run docker-compose command 
In .env the environment variable can't include an other environment variable.
