### PR TITLE
disable splitDB in testnet_config

### DIFF
--- a/config_testnet.yaml
+++ b/config_testnet.yaml
@@ -40,10 +40,6 @@ blockSync:
   maxRepeat: 3
   repeatDecayStep: 3
 
-db:
-  splitDBHeight: 900000
-  splitDBSizeMB: 640
-
 log:
   zap:
     level: info


### PR DESCRIPTION
it should be disabled with Easter-cut (default) 