### PR TITLE
fix sre-portal 51

### DIFF
--- a/config_mainnet.yaml
+++ b/config_mainnet.yaml
@@ -6,6 +6,8 @@ network:
     - /dns4/bootnode-1.mainnet.iotex.one/tcp/4689/p2p/12D3KooWN4TQ1CWRA7yvJdQCdti1qARLXXu2UEHJfycn3XbnAnRh
     - /dns4/bootnode-2.mainnet.iotex.one/tcp/4689/p2p/12D3KooWSiktocuUke16bPoW9zrLawEBaEc1UriaPRwm82xbr2BQ
     - /dns4/bootnode-3.mainnet.iotex.one/tcp/4689/p2p/12D3KooWEsmwaorbZX3HRCnhkMPjMAHzwu3om1pdGrtVm2QaM35n
+    - /dns4/bootnode-4.mainnet.iotex.one/tcp/4689/p2p/12D3KooWHRcgNim4Nau73EEu7aKJZRZPZ21vQ7BE3fG6vENXkduB
+    - /dns4/bootnode-5.mainnet.iotex.one/tcp/4689/p2p/12D3KooWGeHkVDQQFxXpTX1WpPhuuuWYTxPYDUTmaLWWSYx5rmUY
 
 chain:
   # If you are a delegate, make sure producerPrivKey is the key for the operator address you have registered.

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -421,7 +421,7 @@ function main() {
         popd
     fi
 
-    wantdownload=Y
+    wantdownload=N
     read -p "Do you prefer to start from a snapshot, This will overwrite existing data. Download the db file. [Y/N] (Default: Y)? " wantdownload
     if [ "$_PLUGINS_"X = "gateway"X ];then
 


### PR DESCRIPTION
- add 2 aws bootnode config
- the default answer of "start from a snapshot" set  N