### PR TITLE
set testnet chainID = 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v1.6.0/confi
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v1.6.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
+**Special note:** we have recently adjusted the chainID config for testnet, so need to download latest `config_testnet.yaml` 
+instead of v1.6.0. Use the following command to replace the above one:
+```
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+```
+the `genesis_testnet.yaml` file can continue to use v1.6.0
+
 In step 4, you need to use the snapshot for TestNet: https://t.iotex.me/testnet-data-latest and https://t.iotex.me/testnet-data-with-idx-latest. If you need legacy delegate election data(poll.db) for TestNet, you can download it here: https://storage.googleapis.com/blockchain-golden/poll.testnet.tar.gz
 
 ## <a name="ioctl"/>Interact with Blockchain

--- a/README_CN.md
+++ b/README_CN.md
@@ -161,6 +161,11 @@ nohup $IOTEX_HOME/iotex-server \
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v1.6.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v1.6.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
+**特别通知**我们最近调整了 testnet的 chainID设置，您需要使用最新版本的 `config_testnet.yaml`文件，用如下这个命令替换上面第一个下载命令：
+```
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+```
+`genesis_testnet.yaml`可以继续使用 v1.6.0版本
 
 在步骤四中，您需要使用针对于测试网络的数据快照:  https://t.iotex.me/testnet-data-latest 和 https://t.iotex.me/testnet-data-with-idx-latest （如果节点启用了网关）. 如果您需要使用测试网中旧的节点代表数据（poll.db），可以在此处下载:  https://storage.googleapis.com/blockchain-golden/poll.testnet.tar.gz
 

--- a/config_testnet.yaml
+++ b/config_testnet.yaml
@@ -7,6 +7,7 @@ network:
 
 chain:
   # producerPrivKey: SET YOUR PRIVATE KEY HERE (e.g., 96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8)
+  id: 2
   evmNetworkID: 4690
   chainDBPath: "/var/data/chain.db"
   trieDBPath: "/var/data/trie.db"


### PR DESCRIPTION
tested working fine on testnet
1. helps p2p to only process message with correct chainID
2. also prepares for enforcing chainID in tx in upcoming release