### PR TITLE
Minimize node downtime during upgrade, add AI agent mode (non-interactive)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,18 @@ See `release_flow.md` for the complete release process.
 bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/setup_fullnode.sh)
 ```
 
-### One-line upgrade
+### One-line upgrade (interactive)
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/setup_fullnode.sh)
 ```
+
+### Non-interactive upgrade (AI agent / CI)
+```bash
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.3.8
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
+```
+Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).
 
 ### Run with gateway plugin (for API serving)
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Enable Logrotate](#log)
 - [Operate Your Node](#ops)
 - [Upgrade Your Node（One Line Upgrader）](#upgrade)
+- [AI Agent Upgrade (Non-Interactive)](#agent-upgrade)
 - [Q&A](#qa)
 
 ## <a name="status"/>Release Status
@@ -291,6 +292,41 @@ To stop auto upgdrade cron job and iotex server program, you can run
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/stop_fullnode.sh)
 ```
+## <a name="agent-upgrade"/>AI Agent Upgrade (Non-Interactive)
+
+The upgrade script supports a non-interactive mode for use with AI agents, CI/CD pipelines, or automation tools. Use the `--auto` flag to skip all interactive prompts.
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--auto` | Non-interactive mode, skip all prompts |
+| `--home=/path` | Set `$IOTEX_HOME` directory |
+| `--version=v2.3.8` | Target version (default: latest release) |
+| `--force` | Reinstall even if already running the same version |
+| `--monitor` | Enable monitoring |
+| `plugin=gateway` | Enable gateway plugin |
+
+**Upgrade to latest version:**
+```bash
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var
+```
+
+**Upgrade to a specific version:**
+```bash
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.3.8
+```
+
+**Force reinstall same version:**
+```bash
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force
+```
+
+**Notes:**
+- The script auto-detects `IOTEX_HOME` from the running container if `--home` is not specified in interactive mode.
+- Existing `producerPrivKey` and `externalHost` are preserved during upgrades. If no key is configured, the node will use a random key.
+- The old container is stopped as late as possible (after docker pull and config downloads) to minimize downtime.
+
 ## <a name="gateway"/> Gateway Plugin
 Node with gateway plugin enabled will perform extra indexing to serve API requests of more detail chain information, such as number of actions in a block or query actions by hash.
 

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -14,6 +14,8 @@ NC='\033[0m' # No Color
 
 _NEED_INSTALL_=0
 _PLUGINS_CHANGE_=0
+_AUTO_=0
+_FORCE_=0
 
 pushd () {
     command pushd "$@" > /dev/null
@@ -64,22 +66,32 @@ function setVar() {
 function processParam() {
     _ENV_=mainnet
     _GREP_STRING_=MainNet
-    if [ $# -gt 0 ];then
-        if [ "$1"X = "testnet"X ];then
-            _ENV_=testnet
-            _GREP_STRING_=TestNet
-        elif [ "$1"X = "plugin=gateway"X ];then
-            _PLUGINS_=gateway
-        fi
-    fi
-    if [ $# -gt 1 ];then
-        if [ "$2"X = "testnet"X ];then
-            _ENV_=testnet
-            _GREP_STRING_=TestNet
-        elif [ "$2"X = "plugin=gateway"X ];then
-            _PLUGINS_=gateway
-        fi
-    fi
+    for arg in "$@"; do
+        case "$arg" in
+            testnet)
+                _ENV_=testnet
+                _GREP_STRING_=TestNet
+                ;;
+            plugin=gateway)
+                _PLUGINS_=gateway
+                ;;
+            --auto)
+                _AUTO_=1
+                ;;
+            --home=*)
+                IOTEX_HOME="${arg#--home=}"
+                ;;
+            --version=*)
+                _FORCE_VERSION_="${arg#--version=}"
+                ;;
+            --monitor)
+                _FORCE_MONITOR_=Y
+                ;;
+            --force)
+                _FORCE_=1
+                ;;
+        esac
+    done
     env=$_ENV_
 
     # Use for auto-update
@@ -101,10 +113,14 @@ function determinePluginIsChanged() {
 }
 
 function determinIotexHome() {
+    if [ $_AUTO_ -eq 1 ] && [ -n "$IOTEX_HOME" ];then
+        echo "Using IOTEX_HOME=$IOTEX_HOME"
+        return
+    fi
     ##Input Data Dir
     echo "The current user of the input directory must have write permission!!!"
     echo -e "${RED} If Upgrade ; input your old directory \$IOTEX_HOME !!! ${NC}"
-    
+
     #while True: do
     read -p "Input your \$IOTEX_HOME [e.g., $defaultdatadir]: " inputdir
     IOTEX_HOME=${inputdir:-"$defaultdatadir"}
@@ -152,11 +168,16 @@ function enableMonitor() {
 }
 
 function checkPrivateKey() {
+    _HAS_PRIVKEY_=0
     if [ -f ${IOTEX_HOME}/etc/config.yaml ];then
         grep '^  producerPrivKey:' ${IOTEX_HOME}/etc/config.yaml > /dev/null
-        if [ $? -ne 0 ];then
-            _NEED_INSTALL_=1
+        if [ $? -eq 0 ];then
+            _HAS_PRIVKEY_=1
         fi
+    fi
+    # Fresh install is determined by absence of chain.db, not by key
+    if [ ! -f "${IOTEX_HOME}/data/chain.db" ];then
+        _NEED_INSTALL_=1
     fi
 }
 
@@ -191,30 +212,40 @@ function procssNotUpdate() {
     fi
 }
 
-function cleanOldVersion() {
-    echo "Stop old iotex-core"
+function backupOldConfig() {
+    echo -e "${YELLOW} ******  Upgrade IoTeX Node ******* ${NC}"
+    echo -e "${YELLOW} ***  Will stop, delete old iotex container; ${NC}"
+    echo -e "${YELLOW} *** download new config and recover your externalHost producerPrivKey ${NC}"
+    if [ $_AUTO_ -eq 0 ];then
+        read -p "******* Press any key to continue ... [Ctrl + c exit!] " upgreadekey
+    fi
+
+    # Backup externalHost
+    externalHost=$(grep '^  externalHost:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
+    ip=$(echo $externalHost|awk -F':' '{print$2}')
+    if [ -z "$ip" ];then
+        determineExtIp
+    fi
+
+    # Backup producerPrivKey if it exists
+    if [ $_HAS_PRIVKEY_ -eq 1 ];then
+        producerPrivKey=$(grep '^  producerPrivKey:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
+        privKey=$(echo $producerPrivKey|awk -F':' '{print$2}')
+    else
+        echo "No producerPrivKey found — node will use a random key"
+        privKey=""
+        producerPrivKey=""
+    fi
+
+    # Extract existing admin port
+    adminPort=$(grep '^  httpAdminPort:' ${IOTEX_HOME}/etc/config.yaml|awk -F':' '{print$2}'|tr -d ' ')
+}
+
+function stopAndRemoveContainer() {
+    echo "Stop old iotex-core (downtime starts now)"
     docker stop iotex
     echo "delete old iotex docker container"
     docker rm iotex
-    if [ $_NEED_INSTALL_ -eq 0 ];then
-        echo -e "${YELLOW} ******  Upgrade IoTeX Node ******* ${NC}"
-        echo -e "${YELLOW} ***  Will stop, delete old iotex container; ${NC}"
-        echo -e "${YELLOW} *** download new config and recover your externalHost producerPrivKey ${NC}"
-        read -p "******* Press any key to continue ... [Ctrl + c exit!] " upgreadekey
-
-        # Has old producerPrivKey and externalHost
-        producerPrivKey=$(grep '^  producerPrivKey:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
-        externalHost=$(grep '^  externalHost:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
-        privKey=$(echo $producerPrivKey|awk -F':' '{print$2}')
-        ip=$(echo $externalHost|awk -F':' '{print$2}')
-        # Extract existing admin port
-        adminPort=$(grep '^  httpAdminPort:' ${IOTEX_HOME}/etc/config.yaml|awk -F':' '{print$2}'|tr -d ' ')
-    else
-        # No old producerPrivKey and externalHost
-        determineExtIp
-        determinPrivKey
-        determineAdminPort
-    fi
 }
 
 function determineExtIp() {
@@ -281,7 +312,9 @@ function downloadConfig() {
     echo "Update your externalHost,producerPrivKey to config.yaml"
     if [ $SED_IS_GNU -eq 1 ];then
         sed -i "/^network:/a\ \ $externalHost" $IOTEX_HOME/etc/config.yaml
-        sed -i "/^chain:/a\ \ $producerPrivKey" $IOTEX_HOME/etc/config.yaml
+        if [ -n "$producerPrivKey" ];then
+            sed -i "/^chain:/a\ \ $producerPrivKey" $IOTEX_HOME/etc/config.yaml
+        fi
         # Add admin port if set
         if [ -n "$adminPort" ]; then
             echo "Adding httpAdminPort: $adminPort to config.yaml"
@@ -297,9 +330,11 @@ function downloadConfig() {
         sed -i '' "/^network:/a\
 \ \ $externalHost
 " $IOTEX_HOME/etc/config.yaml
-        sed -i '' "/^chain:/a\
+        if [ -n "$producerPrivKey" ];then
+            sed -i '' "/^chain:/a\
 \ \ $producerPrivKey
 " $IOTEX_HOME/etc/config.yaml
+        fi
         # Add admin port if set
         if [ -n "$adminPort" ]; then
             echo "Adding httpAdminPort: $adminPort to config.yaml"
@@ -441,21 +476,25 @@ function main() {
     checkPrivateKey            # Determine the producerPrivKey in the config file is exist.
     checkAndCleanAutoUpdate    # Check if auto-update is installed, then kill and clean it.
 
-    deleteOldFile              # Clean up historical legacy files
-    
     # Interactive setup phase
-    read -p "Do you want to monitor the status of the node [Y/N] (Default: N)? " wantmonitor
+    if [ $_AUTO_ -eq 1 ];then
+        wantmonitor=${_FORCE_MONITOR_:-N}
+    else
+        read -p "Do you want to monitor the status of the node [Y/N] (Default: N)? " wantmonitor
+    fi
 
     if [ $_PLUGINS_ ] && [ "$_PLUGINS_"X = "gateway"X ];then
-        plugins=Y    
+        plugins=Y
     else
         plugins=N
     fi
 
-    read -p "Do you want to enable gateway plugin [Y/N] (Default: $plugins)? " plugins
-    if [ "${plugins}X" = "yX" ] || [ "${plugins}X" = "YX" ];then
-        _PLUGINS_=gateway
-        echo "Gateway plugin enabled"
+    if [ $_AUTO_ -eq 0 ];then
+        read -p "Do you want to enable gateway plugin [Y/N] (Default: $plugins)? " plugins
+        if [ "${plugins}X" = "yX" ] || [ "${plugins}X" = "YX" ];then
+            _PLUGINS_=gateway
+            echo "Gateway plugin enabled"
+        fi
     fi
 
     # Get the latest version.
@@ -465,8 +504,12 @@ function main() {
     fi
 
     echo -e "Current operating environment: ${YELLOW}  $env ${NC}"
-    read -p "Install or Upgrade Version; if null the latest [$lastversion]: " ver
-    version=${ver:-"$lastversion"}   # if $ver ;then version=$ver;else version=$lastversion"
+    if [ $_AUTO_ -eq 1 ];then
+        version=${_FORCE_VERSION_:-"$lastversion"}
+    else
+        read -p "Install or Upgrade Version; if null the latest [$lastversion]: " ver
+        version=${ver:-"$lastversion"}   # if $ver ;then version=$ver;else version=$lastversion"
+    fi
 
     # Get the running version.
     docker ps -a |grep "iotex/iotex-core:v" > /dev/null 2>&1
@@ -480,7 +523,7 @@ function main() {
         # Check if the plugin needs to be changed
         determinePluginIsChanged
 
-        if [ "$version"X = "$runversion"X ] && [ $_PLUGINS_CHANGE_ -eq 0 ];then
+        if [ "$version"X = "$runversion"X ] && [ $_PLUGINS_CHANGE_ -eq 0 ] && [ $_FORCE_ -eq 0 ];then
             # Do nothing
             procssNotUpdate
             exit 0
@@ -488,9 +531,11 @@ function main() {
     fi
 
     # Need update or install
+    _IS_UPGRADE_=0
     if [ -f "${IOTEX_HOME}/data/chain.db" ];then
-        # Clean old version.
-        cleanOldVersion
+        _IS_UPGRADE_=1
+        # Backup config while node is still running
+        backupOldConfig
     else
         determineExtIp
         determinPrivKey
@@ -498,7 +543,9 @@ function main() {
 
         echo -e "${YELLOW} ****** Install IoTeX Node  ***** ${NC}"
         echo -e "${YELLOW} if installed, Confirm Input IOTEX_HOME directory $IOTEX_HOME True ${NC};"
-        read -p "[Ctrl + c exit!]; else Enter anykey ..." anykey
+        if [ $_AUTO_ -eq 0 ];then
+            read -p "[Ctrl + c exit!]; else Enter anykey ..." anykey
+        fi
 
         mkdir -p ${IOTEX_HOME}
         pushd ${IOTEX_HOME}
@@ -507,34 +554,31 @@ function main() {
     fi
 
     wantdownload=N
-    read -p "Do you prefer to start from a snapshot, This will overwrite existing data. Download the db file. [Y/N] (Default: N)? " wantdownload
-    if [ "$_PLUGINS_"X = "gateway"X ];then
-
-        if [[ "$runversion" == "v1.1"* && "$version" == "v1.2"* ]] && ([ "$wantdownload"X = "N"X ] || [ "$wantdownload"X = "n"X ]);then
-            read -p "Confirm that the current bloomfilter.index.db file will be deleted to be forward-compatible." dbf
-            pushd ${IOTEX_HOME}
-            rm -f data/bloomfilter.index.db || echo 'Not exist bloomfilter.index.db.'
-            popd
+    if [ $_AUTO_ -eq 0 ];then
+        read -p "Do you prefer to start from a snapshot, This will overwrite existing data. Download the db file. [Y/N] (Default: N)? " wantdownload
+        if [ "$_PLUGINS_"X = "gateway"X ];then
+            if [[ "$runversion" == "v1.1"* && "$version" == "v1.2"* ]] && ([ "$wantdownload"X = "N"X ] || [ "$wantdownload"X = "n"X ]);then
+                read -p "Confirm that the current bloomfilter.index.db file will be deleted to be forward-compatible." dbf
+                pushd ${IOTEX_HOME}
+                rm -f data/bloomfilter.index.db || echo 'Not exist bloomfilter.index.db.'
+                popd
+            fi
         fi
     fi
-    
-    if [ "${wantdownload}X" = "YX" ] || [ "${wantdownload}X" = "yX" ];then
-        # Download db file
-        donwloadBlockDataFile
-    fi
-
 
     echo -e "Confirm your externalHost: ${YELLOW} $ip ${NC}"
     echo -e "Confirm your producerPrivKey: ${RED} $privKey ${NC}"
     if [ -n "$adminPort" ]; then
         echo -e "Confirm your adminPort: ${YELLOW} $adminPort ${NC}"
     fi
-    read -p "Press any key to continue ... [Ctrl + c exit!] " key2
+    if [ $_AUTO_ -eq 0 ];then
+        read -p "Press any key to continue ... [Ctrl + c exit!] " key2
+    fi
 
+    # All heavy downloads happen while the old node is still running
     echo "docker pull iotex-core ${version}"
     docker pull iotex/iotex-core:${version}
     # or use gcr.io/iotex-servers/iotex-core:${version}
-    #Set the environment with the following commands:
 
     downloadConfig
     preDockerCompose
@@ -547,7 +591,20 @@ function main() {
     # Add admin port mapping to docker-compose.yml if set
     addAdminPortToCompose
 
+    # --- Downtime starts here: stop old container as late as possible ---
+    if [ $_IS_UPGRADE_ -eq 1 ];then
+        stopAndRemoveContainer
+    fi
+
+    deleteOldFile
+
+    # Extract snapshot after container is stopped (writes to mounted data dir)
+    if [ "${wantdownload}X" = "YX" ] || [ "${wantdownload}X" = "yX" ];then
+        donwloadBlockDataFile
+    fi
+
     startupNode
+    # --- Downtime ends here ---
 
     checkAndCleanAutoUpdate
 }

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -121,11 +121,28 @@ function detectIotexHome() {
 }
 
 function determinIotexHome() {
-    if [ $_AUTO_ -eq 1 ] && [ -n "$IOTEX_HOME" ];then
-        echo "Using IOTEX_HOME=$IOTEX_HOME"
-        return
+    # In auto mode, avoid interactive prompts.
+    if [ $_AUTO_ -eq 1 ];then
+        # If IOTEX_HOME is already set, just use it.
+        if [ -n "$IOTEX_HOME" ];then
+            echo "Using IOTEX_HOME=$IOTEX_HOME"
+            return
+        fi
+
+        # Try to auto-detect IOTEX_HOME from a running container.
+        local detected=$(detectIotexHome)
+        if [ -n "$detected" ];then
+            IOTEX_HOME="$detected"
+            echo "Using auto-detected IOTEX_HOME=$IOTEX_HOME"
+            return
+        fi
+
+        # In auto mode, we cannot prompt; fail fast with a clear error.
+        echo "Error: --auto mode requires --home to be specified or an existing IoTeX container to detect IOTEX_HOME." >&2
+        exit 1
     fi
 
+    # Non-auto mode: optionally auto-detect and then prompt the user.
     # Auto-detect from running container
     local detected=$(detectIotexHome)
     if [ -n "$detected" ];then
@@ -230,9 +247,14 @@ function procssNotUpdate() {
 function backupOldConfig() {
     # Backup externalHost
     externalHost=$(grep '^  externalHost:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
-    ip=$(echo $externalHost|awk -F':' '{print$2}')
+    ip=$(echo "$externalHost" | awk -F':' '{print $2}' | xargs)
     if [ -z "$ip" ];then
-        determineExtIp
+        if [ "$_AUTO_" -eq 1 ]; then
+            echo "Error: externalHost is missing or invalid in ${IOTEX_HOME}/etc/config.yaml; cannot continue auto-upgrade."
+            exit 1
+        else
+            determineExtIp
+        fi
     fi
 
     # Backup producerPrivKey if it exists

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -112,11 +112,26 @@ function determinePluginIsChanged() {
     fi
 }
 
+function detectIotexHome() {
+    # Try to detect IOTEX_HOME from running iotex container mounts
+    local detected=$(docker inspect iotex --format '{{range .HostConfig.Binds}}{{println .}}{{end}}' 2>/dev/null | grep config_override | sed 's|/etc/config.yaml:/etc/iotex/config_override.yaml:ro||')
+    if [ -n "$detected" ];then
+        echo "$detected"
+    fi
+}
+
 function determinIotexHome() {
     if [ $_AUTO_ -eq 1 ] && [ -n "$IOTEX_HOME" ];then
         echo "Using IOTEX_HOME=$IOTEX_HOME"
         return
     fi
+
+    # Auto-detect from running container
+    local detected=$(detectIotexHome)
+    if [ -n "$detected" ];then
+        defaultdatadir="$detected"
+    fi
+
     ##Input Data Dir
     echo "The current user of the input directory must have write permission!!!"
     echo -e "${RED} If Upgrade ; input your old directory \$IOTEX_HOME !!! ${NC}"
@@ -553,6 +568,12 @@ function main() {
         popd
     fi
 
+    echo -e "Confirm your externalHost: ${YELLOW} $ip ${NC}"
+    echo -e "Confirm your producerPrivKey: ${RED} $privKey ${NC}"
+    if [ -n "$adminPort" ]; then
+        echo -e "Confirm your adminPort: ${YELLOW} $adminPort ${NC}"
+    fi
+
     wantdownload=N
     if [ $_AUTO_ -eq 0 ];then
         read -p "Do you prefer to start from a snapshot, This will overwrite existing data. Download the db file. [Y/N] (Default: N)? " wantdownload
@@ -564,14 +585,7 @@ function main() {
                 popd
             fi
         fi
-    fi
 
-    echo -e "Confirm your externalHost: ${YELLOW} $ip ${NC}"
-    echo -e "Confirm your producerPrivKey: ${RED} $privKey ${NC}"
-    if [ -n "$adminPort" ]; then
-        echo -e "Confirm your adminPort: ${YELLOW} $adminPort ${NC}"
-    fi
-    if [ $_AUTO_ -eq 0 ];then
         read -p "Press any key to continue ... [Ctrl + c exit!] " key2
     fi
 

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -228,13 +228,6 @@ function procssNotUpdate() {
 }
 
 function backupOldConfig() {
-    echo -e "${YELLOW} ******  Upgrade IoTeX Node ******* ${NC}"
-    echo -e "${YELLOW} ***  Will stop, delete old iotex container; ${NC}"
-    echo -e "${YELLOW} *** download new config and recover your externalHost producerPrivKey ${NC}"
-    if [ $_AUTO_ -eq 0 ];then
-        read -p "******* Press any key to continue ... [Ctrl + c exit!] " upgreadekey
-    fi
-
     # Backup externalHost
     externalHost=$(grep '^  externalHost:' ${IOTEX_HOME}/etc/config.yaml|sed 's/^  //g')
     ip=$(echo $externalHost|awk -F':' '{print$2}')
@@ -586,7 +579,13 @@ function main() {
             fi
         fi
 
-        read -p "Press any key to continue ... [Ctrl + c exit!] " key2
+    fi
+
+    # Last chance to bail out before making changes
+    if [ $_IS_UPGRADE_ -eq 1 ] && [ $_AUTO_ -eq 0 ];then
+        echo -e "${YELLOW} ******  Upgrade IoTeX Node ******* ${NC}"
+        echo -e "${YELLOW} ***  Will pull new image, download config, then stop and replace the container. ${NC}"
+        read -p "******* Press any key to continue ... [Ctrl + c exit!] " upgreadekey
     fi
 
     # All heavy downloads happen while the old node is still running


### PR DESCRIPTION
## Summary
- Defer `docker stop/rm` to right before startup so `docker pull`, config download, and compose setup all happen while the old node is still running — reducing downtime from minutes to seconds
- Add `--auto` flag for non-interactive upgrades (agent/CI friendly), with `--home`, `--version`, `--force`, and `--monitor` flags
- Fix upgrade detection: use `chain.db` existence instead of `producerPrivKey` presence, so keyless standby nodes upgrade correctly without being treated as fresh installs
- Skip `producerPrivKey` injection when no key is configured (node gets a random key)

## Test plan
- [x] Tested `--auto --force` upgrade on keyless node: no key injected, node gets random key
- [x] Tested `--auto --force` upgrade with existing key: key preserved after upgrade
- [x] Tested same-version skip works without `--force`
- [x] Syntax check passes (`bash -n`)