### PR TITLE
Add --snapshot flag and agent setup guide

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,84 @@
+# IoTeX Node Setup & Upgrade Guide for AI Agents
+
+Practical knowledge for AI agents setting up or upgrading an IoTeX mainnet fullnode. Covers pitfalls not obvious from the main README.
+
+## Prerequisites
+
+1. **Docker** — must be installed first. The setup script checks but does NOT install it:
+   ```bash
+   curl -fsSL https://get.docker.com | sh
+   ```
+
+2. **docker-compose standalone binary** — the script requires `docker-compose` (not `docker compose` plugin syntax). Modern Docker ships the plugin but not the standalone binary:
+   ```bash
+   ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+   ```
+
+3. **Non-root user (recommended)** — install Docker as root, then create a node user with docker group access:
+   ```bash
+   useradd -m -s /bin/bash <username>
+   usermod -aG docker <username>
+   ```
+
+## Fresh Install
+
+### Before you start
+
+1. **Check available disk space** — a core node needs at least 500GB free, a gateway node needs 1TB+:
+   ```bash
+   df -h /
+   ```
+2. **Choose the install path** — pick the partition with the most space. Recommend `$HOME/iotex-var` if the home partition is large enough, otherwise use the largest mounted volume (e.g., `/data/iotex-var`, `/mnt/iotex-var`). Ask the user if unclear.
+
+### Run the setup
+
+```bash
+# Download the setup script — note: it's under scripts/, NOT repo root
+curl -sSL https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/setup_fullnode.sh -o ~/setup_fullnode.sh
+
+# Run with --snapshot to download blockchain data (~180GB, takes 1-3 hours)
+bash ~/setup_fullnode.sh --auto --home=<install-path> --snapshot
+```
+
+See the [main README](README.md#agent-upgrade) for all available flags.
+
+### Key things to know
+
+- **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
+- **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
+- **The snapshot download is blocking** and can take hours. For manual background download:
+  ```bash
+  nohup bash -c "\
+    curl -L -C - -o $HOME/iotex-var/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest && \
+    tar -xzf $HOME/iotex-var/data.tar.gz -C $HOME/iotex-var/data/ && \
+    echo DONE > $HOME/iotex-var/snapshot.status \
+  " > $HOME/iotex-var/snapshot.log 2>&1 &
+  ```
+- **Disk space:** if the target partition has less than 500GB free, warn the user before proceeding.
+
+## Upgrade
+
+```bash
+bash ~/setup_fullnode.sh --auto --home=$HOME/iotex-var
+```
+
+Upgrades preserve `externalHost`, `producerPrivKey`, and `adminPort`. No snapshot download needed — only the binary and configs are updated. Downtime is minimized by pulling the new image before stopping the old container.
+
+## Verify
+
+```bash
+docker ps | grep iotex
+docker logs -f --tail 20 iotex | grep -E "height|sync|error"
+```
+
+The node is healthy when block heights are increasing with no `fatal` errors.
+
+## Ports
+
+| Port | Purpose | Required |
+|---|---|---|
+| 4689 | P2P network | Always |
+| 8080 | HTTP stats | Always |
+| 14014 | gRPC API | Gateway only |
+| 15014 | Ethereum JSON-RPC API | Gateway only |
+| 16014 | Ethereum WebSocket | Gateway only |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Enable Logrotate](#log)
 - [Operate Your Node](#ops)
 - [Upgrade Your Node（One Line Upgrader）](#upgrade)
-- [AI Agent Upgrade (Non-Interactive)](#agent-upgrade)
+- [Agent Guide](AGENT.md)
 - [Q&A](#qa)
 
 ## <a name="status"/>Release Status
@@ -292,11 +292,10 @@ To stop auto upgdrade cron job and iotex server program, you can run
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/stop_fullnode.sh)
 ```
-## <a name="agent-upgrade"/>AI Agent Upgrade (Non-Interactive)
+
+### Auto Mode (Non-Interactive)
 
 The upgrade script supports a non-interactive mode for use with AI agents, CI/CD pipelines, or automation tools. Use the `--auto` flag to skip all interactive prompts.
-
-**Flags:**
 
 | Flag | Description |
 |---|---|
@@ -304,28 +303,25 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 | `--home=/path` | Set `$IOTEX_HOME` directory |
 | `--version=v2.3.8` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
+| `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
 | `plugin=gateway` | Enable gateway plugin |
 
-**Upgrade to latest version:**
 ```bash
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-```
+# Fresh install with snapshot
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 
-**Upgrade to a specific version:**
-```bash
+# Upgrade to latest version
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var
+
+# Upgrade to a specific version
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.3.8
 ```
 
-**Force reinstall same version:**
-```bash
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force
-```
-
 **Notes:**
-- The script auto-detects `IOTEX_HOME` from the running container if `--home` is not specified in interactive mode.
-- Existing `producerPrivKey` and `externalHost` are preserved during upgrades. If no key is configured, the node will use a random key.
-- The old container is stopped as late as possible (after docker pull and config downloads) to minimize downtime.
+- Existing `producerPrivKey` and `externalHost` are preserved during upgrades.
+- The old container is stopped as late as possible to minimize downtime.
+- See the [Agent Guide](AGENT.md) for detailed setup instructions and common pitfalls.
 
 ## <a name="gateway"/> Gateway Plugin
 Node with gateway plugin enabled will perform extra indexing to serve API requests of more detail chain information, such as number of actions in a block or query actions by hash.

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -16,6 +16,7 @@ _NEED_INSTALL_=0
 _PLUGINS_CHANGE_=0
 _AUTO_=0
 _FORCE_=0
+_SNAPSHOT_=0
 
 pushd () {
     command pushd "$@" > /dev/null
@@ -89,6 +90,9 @@ function processParam() {
                 ;;
             --force)
                 _FORCE_=1
+                ;;
+            --snapshot)
+                _SNAPSHOT_=1
                 ;;
         esac
     done
@@ -590,7 +594,9 @@ function main() {
     fi
 
     wantdownload=N
-    if [ $_AUTO_ -eq 0 ];then
+    if [ $_AUTO_ -eq 1 ] && [ $_SNAPSHOT_ -eq 1 ];then
+        wantdownload=Y
+    elif [ $_AUTO_ -eq 0 ];then
         read -p "Do you prefer to start from a snapshot, This will overwrite existing data. Download the db file. [Y/N] (Default: N)? " wantdownload
         if [ "$_PLUGINS_"X = "gateway"X ];then
             if [[ "$runversion" == "v1.1"* && "$version" == "v1.2"* ]] && ([ "$wantdownload"X = "N"X ] || [ "$wantdownload"X = "n"X ]);then


### PR DESCRIPTION
## Summary
- Add `--snapshot` flag to `setup_fullnode.sh` for non-interactive snapshot download, enabling fully unattended fresh installs via `--auto --snapshot`
- Add `AGENT.md` with practical setup/upgrade knowledge for AI agents and automation tools — covers prerequisites, common pitfalls (expired Infura key, docker-compose symlink, IPv4 requirement for externalHost), disk space checks, and install path recommendations
- Consolidate the standalone "AI Agent Upgrade" README section into the existing "Upgrade Your Node" section as an "Auto Mode (Non-Interactive)" subsection

## Test plan
- [ ] Run `bash setup_fullnode.sh --auto --home=/tmp/iotex-test --snapshot` on a fresh server and verify snapshot downloads and node starts
- [ ] Run `bash setup_fullnode.sh --auto --home=/tmp/iotex-test` (without `--snapshot`) and verify it skips download as before
- [ ] Verify interactive mode still prompts for snapshot download as before