### PR TITLE
AGENT.md: stream extraction and disk size analysis

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -24,13 +24,15 @@ Practical knowledge for AI agents setting up or upgrading an IoTeX mainnet fulln
 
 ### Before you start
 
-1. **Check available disk space** — run `df -h` and analyze ALL mounted partitions, then check the actual snapshot size on `storage.iotex.io`:
+1. **Check available disk space** — first check the actual snapshot size, then compare against free disk:
    ```bash
+   # Step 1: Check current compressed snapshot size (as of 2026-04, ~182GB compressed, ~265GB extracted)
+   curl -sIL https://t.iotex.me/mainnet-data-snapshot-core-latest 2>/dev/null | grep -i content-length
+   # Step 2: Check free disk on all partitions
    df -h
-   # Check current snapshot sizes (compressed .tar.gz and extracted)
-   curl -sI https://t.iotex.me/mainnet-data-snapshot-core-latest 2>/dev/null | grep -i content-length
    ```
-   - Gateway node: much larger than core — 1TB+ required.
+   - These sizes grow over time — always check the URL first, don't rely on the numbers above.
+   - Core node: extracted size + growth headroom (as of 2026-04, ~300GB minimum). Gateway node: 1TB+.
    - If using stream extraction (curl | tar), only the extracted size is needed. If downloading tarball first, both compressed + extracted sizes are needed.
    - If no single partition is large enough, tell the user to resize the disk or attach additional storage before proceeding.
 2. **Choose the install path** — pick the partition with the most space. Recommend `$HOME/iotex-var` if the home partition is large enough, otherwise use the largest mounted volume (e.g., `/data/iotex-var`, `/mnt/iotex-var`). Ask the user if unclear.
@@ -51,7 +53,7 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 
 - **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
 - **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
-- **Snapshot size analysis:** Before downloading, check the actual snapshot size on `storage.iotex.io` and compare against free disk space. Snapshot sizes grow over time — do not hardcode assumptions.
+- **Snapshot size analysis:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04). These sizes grow over time — always verify by checking the URL as shown above.
   - **Stream extraction (recommended):** Pipe curl directly into tar — no intermediate file, only needs enough space for the extracted data:
     ```bash
     # Install pigz for parallel decompression (much faster on multi-core)
@@ -69,7 +71,7 @@ See the [main README](README.md#agent-upgrade) for all available flags.
     " > $IOTEX_HOME/snapshot.log 2>&1 &
     ```
   - If the partition cannot hold both the compressed and extracted data, use stream extraction. If it cannot hold even the extracted data, the disk is too small — warn the user.
-- **Disk space:** check `storage.iotex.io` for current snapshot sizes and ensure the target partition has enough free space plus growth headroom. A gateway node needs 1TB+. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
+- **Disk space:** always verify the current snapshot size from the URL before proceeding. Ensure the target partition has enough free space plus growth headroom. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
 
 ## Upgrade
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -24,13 +24,14 @@ Practical knowledge for AI agents setting up or upgrading an IoTeX mainnet fulln
 
 ### Before you start
 
-1. **Check available disk space** — run `df -h` and analyze ALL mounted partitions:
+1. **Check available disk space** — run `df -h` and analyze ALL mounted partitions, then check the actual snapshot size on `storage.iotex.io`:
    ```bash
    df -h
+   # Check current snapshot sizes (compressed .tar.gz and extracted)
+   curl -sI https://t.iotex.me/mainnet-data-snapshot-core-latest 2>/dev/null | grep -i content-length
    ```
-   - Core node: **300GB minimum** (265GB snapshot data + growth). 500GB+ recommended.
-   - Gateway node: **1TB+ required**.
-   - If using stream extraction (curl | tar), only ~265GB needed. If downloading tarball first, ~450GB needed (180GB compressed + 265GB extracted).
+   - Gateway node: much larger than core — 1TB+ required.
+   - If using stream extraction (curl | tar), only the extracted size is needed. If downloading tarball first, both compressed + extracted sizes are needed.
    - If no single partition is large enough, tell the user to resize the disk or attach additional storage before proceeding.
 2. **Choose the install path** — pick the partition with the most space. Recommend `$HOME/iotex-var` if the home partition is large enough, otherwise use the largest mounted volume (e.g., `/data/iotex-var`, `/mnt/iotex-var`). Ask the user if unclear.
 
@@ -50,15 +51,15 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 
 - **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
 - **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
-- **Snapshot size analysis:** Before downloading, check how much free space the target partition has. The snapshot is ~180GB compressed and ~265GB extracted.
-  - **Stream extraction (recommended):** Pipe curl directly into tar — no intermediate file, needs only ~265GB free:
+- **Snapshot size analysis:** Before downloading, check the actual snapshot size on `storage.iotex.io` and compare against free disk space. Snapshot sizes grow over time — do not hardcode assumptions.
+  - **Stream extraction (recommended):** Pipe curl directly into tar — no intermediate file, only needs enough space for the extracted data:
     ```bash
     # Install pigz for parallel decompression (much faster on multi-core)
     apt-get install -y pigz
     mkdir -p $IOTEX_HOME/data
     curl -L -s https://t.iotex.me/mainnet-data-snapshot-core-latest | pigz -d | tar -xf - -C $IOTEX_HOME/data/
     ```
-  - **Two-step download (if you need resume support):** Downloads the tarball first, then extracts. Needs ~450GB free (180GB compressed + 265GB extracted):
+  - **Two-step download (if you need resume support):** Downloads the tarball first, then extracts. Needs enough space for both compressed and extracted data:
     ```bash
     nohup bash -c "\
       curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest && \
@@ -67,8 +68,8 @@ See the [main README](README.md#agent-upgrade) for all available flags.
       echo DONE > $IOTEX_HOME/snapshot.status \
     " > $IOTEX_HOME/snapshot.log 2>&1 &
     ```
-  - If the partition has **less than 300GB free**, use stream extraction. If less than 265GB, the disk is too small — warn the user.
-- **Disk space:** a core node needs at least 300GB free (265GB data + growth headroom). A gateway node needs 1TB+. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
+  - If the partition cannot hold both the compressed and extracted data, use stream extraction. If it cannot hold even the extracted data, the disk is too small — warn the user.
+- **Disk space:** check `storage.iotex.io` for current snapshot sizes and ensure the target partition has enough free space plus growth headroom. A gateway node needs 1TB+. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
 
 ## Upgrade
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -24,10 +24,14 @@ Practical knowledge for AI agents setting up or upgrading an IoTeX mainnet fulln
 
 ### Before you start
 
-1. **Check available disk space** — a core node needs at least 500GB free, a gateway node needs 1TB+:
+1. **Check available disk space** — run `df -h` and analyze ALL mounted partitions:
    ```bash
-   df -h /
+   df -h
    ```
+   - Core node: **300GB minimum** (265GB snapshot data + growth). 500GB+ recommended.
+   - Gateway node: **1TB+ required**.
+   - If using stream extraction (curl | tar), only ~265GB needed. If downloading tarball first, ~450GB needed (180GB compressed + 265GB extracted).
+   - If no single partition is large enough, tell the user to resize the disk or attach additional storage before proceeding.
 2. **Choose the install path** — pick the partition with the most space. Recommend `$HOME/iotex-var` if the home partition is large enough, otherwise use the largest mounted volume (e.g., `/data/iotex-var`, `/mnt/iotex-var`). Ask the user if unclear.
 
 ### Run the setup
@@ -46,15 +50,25 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 
 - **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
 - **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
-- **The snapshot download is blocking** and can take hours. For manual background download:
-  ```bash
-  nohup bash -c "\
-    curl -L -C - -o $HOME/iotex-var/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest && \
-    tar -xzf $HOME/iotex-var/data.tar.gz -C $HOME/iotex-var/data/ && \
-    echo DONE > $HOME/iotex-var/snapshot.status \
-  " > $HOME/iotex-var/snapshot.log 2>&1 &
-  ```
-- **Disk space:** if the target partition has less than 500GB free, warn the user before proceeding.
+- **Snapshot size analysis:** Before downloading, check how much free space the target partition has. The snapshot is ~180GB compressed and ~265GB extracted.
+  - **Stream extraction (recommended):** Pipe curl directly into tar — no intermediate file, needs only ~265GB free:
+    ```bash
+    # Install pigz for parallel decompression (much faster on multi-core)
+    apt-get install -y pigz
+    mkdir -p $IOTEX_HOME/data
+    curl -L -s https://t.iotex.me/mainnet-data-snapshot-core-latest | pigz -d | tar -xf - -C $IOTEX_HOME/data/
+    ```
+  - **Two-step download (if you need resume support):** Downloads the tarball first, then extracts. Needs ~450GB free (180GB compressed + 265GB extracted):
+    ```bash
+    nohup bash -c "\
+      curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest && \
+      tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/ && \
+      rm -f $IOTEX_HOME/data.tar.gz && \
+      echo DONE > $IOTEX_HOME/snapshot.status \
+    " > $IOTEX_HOME/snapshot.log 2>&1 &
+    ```
+  - If the partition has **less than 300GB free**, use stream extraction. If less than 265GB, the disk is too small — warn the user.
+- **Disk space:** a core node needs at least 300GB free (265GB data + growth headroom). A gateway node needs 1TB+. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
 
 ## Upgrade
 


### PR DESCRIPTION
## Summary
- Add stream extraction method (`curl | pigz | tar`) as recommended snapshot download approach — no intermediate file needed, saves ~180GB disk
- Add disk size analysis guidance before download: 265GB min (stream) vs 450GB (two-step)
- Add `pigz` parallel decompression for faster extraction on multi-core servers

## Test plan
- [ ] Verify stream extraction command works on a fresh server
- [ ] Confirm disk size thresholds match current snapshot size