### PR TITLE
AGENT.md: recommend aria2c, validate inputs, fix fresh-install with pre-loaded data

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -42,23 +42,32 @@ Practical knowledge for AI agents setting up or upgrading an IoTeX mainnet fulln
 ```bash
 # Download the setup script — note: it's under scripts/, NOT repo root
 curl -sSL https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/scripts/setup_fullnode.sh -o ~/setup_fullnode.sh
-
-# Run with --snapshot to download blockchain data (~180GB, takes 1-3 hours)
-bash ~/setup_fullnode.sh --auto --home=<install-path> --snapshot
 ```
 
 See the [main README](README.md#agent-upgrade) for all available flags.
 
-### Key things to know
+**Fresh installs need snapshot data.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`. There are two ways to get the snapshot data:
 
-- **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
+- **Option A: Let the script download it (`--snapshot`).** Simple, but downloads the tarball to `$IOTEX_HOME/tmp/` on the same partition, so you need enough disk for both compressed + extracted data.
+  ```bash
+  bash ~/setup_fullnode.sh --auto --home=<install-path> --snapshot
+  ```
+- **Option B: Download the snapshot manually first (recommended).** Supports resume on failure and lets you use a separate disk/volume for the tarball. After extracting to `$IOTEX_HOME/data/`, run the script without `--snapshot` — it detects existing data automatically.
+  ```bash
+  # 1. Download and extract (see "Snapshot download" below for details)
+  # 2. Then run setup without --snapshot
+  bash ~/setup_fullnode.sh --auto --home=<install-path>
+  ```
+
+### Key things to know
 - **Fresh install in `--auto` mode** now works without interactive prompts:
   - `externalHost` is auto-detected via `curl -4 ip.sb` (forced IPv4 — p2p layer does not handle IPv6).
   - A random `producerPrivKey` is auto-generated as a temporary operator wallet.
   - After install, ask the user: "A temporary operator key was generated. Do you want to fund this wallet for staking, or replace it with an existing key in `$IOTEX_HOME/etc/config.yaml`?"
 - **`externalHost` must be IPv4.** The script now uses `curl -4 ip.sb` by default. If the detected IP is wrong, update `$IOTEX_HOME/etc/config.yaml` and restart.
-- **Snapshot download:** The `--snapshot` flag downloads the snapshot to `$IOTEX_HOME/tmp/` and extracts it. This requires enough disk to hold both the compressed tarball and the extracted data on the same partition. The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04) — these sizes grow over time, always verify by checking the URL as shown above.
-  - **Manual download (recommended for large snapshots):** Instead of using `--snapshot`, download the snapshot yourself before running the script. This lets you use a separate disk/volume for the tarball and supports resume on failure. Run the setup script without `--snapshot` afterward — the script detects existing data in `$IOTEX_HOME/data/`:
+- **Snapshot download details:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04) — these sizes grow over time, always verify by checking the URL as shown above.
+  - **Option A (`--snapshot`)** downloads to `$IOTEX_HOME/tmp/` on the same partition. Needs enough disk for compressed + extracted data. No resume on failure.
+  - **Option B (manual, recommended):** Download the tarball yourself — supports resume and separate disk/volume:
     ```bash
     apt-get install -y pigz
     mkdir -p $IOTEX_HOME/data

--- a/AGENT.md
+++ b/AGENT.md
@@ -57,8 +57,8 @@ See the [main README](README.md#agent-upgrade) for all available flags.
   - A random `producerPrivKey` is auto-generated as a temporary operator wallet.
   - After install, ask the user: "A temporary operator key was generated. Do you want to fund this wallet for staking, or replace it with an existing key in `$IOTEX_HOME/etc/config.yaml`?"
 - **`externalHost` must be IPv4.** The script now uses `curl -4 ip.sb` by default. If the detected IP is wrong, update `$IOTEX_HOME/etc/config.yaml` and restart.
-- **Snapshot size analysis:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04). These sizes grow over time — always verify by checking the URL as shown above.
-  - **File download + extract (recommended):** Download the tarball first with resume support, then extract. This is more reliable than streaming for large files — any network interruption resumes from where it left off instead of restarting. If the main disk can't hold both compressed + extracted data, use a temporary volume for the download:
+- **Snapshot download:** The `--snapshot` flag downloads the snapshot to `$IOTEX_HOME/tmp/` and extracts it. This requires enough disk to hold both the compressed tarball and the extracted data on the same partition. The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04) — these sizes grow over time, always verify by checking the URL as shown above.
+  - **Manual download (recommended for large snapshots):** Instead of using `--snapshot`, download the snapshot yourself before running the script. This lets you use a separate disk/volume for the tarball and supports resume on failure. Run the setup script without `--snapshot` afterward — the script detects existing data in `$IOTEX_HOME/data/`:
     ```bash
     apt-get install -y pigz
     mkdir -p $IOTEX_HOME/data

--- a/AGENT.md
+++ b/AGENT.md
@@ -54,24 +54,37 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 - **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
 - **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
 - **Snapshot size analysis:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04). These sizes grow over time — always verify by checking the URL as shown above.
-  - **Stream extraction (recommended):** Pipe curl directly into tar — no intermediate file, only needs enough space for the extracted data:
+  - **File download + extract (recommended):** Download the tarball first with resume support, then extract. This is more reliable than streaming for large files — any network interruption resumes from where it left off instead of restarting. If the main disk can't hold both compressed + extracted data, use a temporary volume for the download:
     ```bash
-    # Install pigz for parallel decompression (much faster on multi-core)
     apt-get install -y pigz
     mkdir -p $IOTEX_HOME/data
-    curl -L -s https://t.iotex.me/mainnet-data-snapshot-core-latest | pigz -d | tar -xf - -C $IOTEX_HOME/data/
+    # Download with resume support (use a separate disk/volume if main disk is too small)
+    DOWNLOAD_DIR=$IOTEX_HOME  # or /mnt/volume if main disk can't hold both
+    until curl -L -C - -o $DOWNLOAD_DIR/snapshot.tar.gz \
+      --retry 20 --retry-delay 10 --speed-limit 100000 --speed-time 120 \
+      https://t.iotex.me/mainnet-data-snapshot-core-latest; do
+      echo "Download interrupted, resuming in 30s..."; sleep 30
+    done
+    # Extract with parallel decompression, then clean up
+    pigz -dc $DOWNLOAD_DIR/snapshot.tar.gz | tar -xf - -C $IOTEX_HOME/data/
+    rm -f $DOWNLOAD_DIR/snapshot.tar.gz
     ```
-  - **Two-step download (if you need resume support):** Downloads the tarball first, then extracts. Needs enough space for both compressed and extracted data:
+    For even faster downloads, use `aria2c -x16 -s16` instead of curl (16 parallel connections). aria2c also supports resume via `--continue=true`.
+  - **Stream extraction (fallback — only when disk is very constrained):** Pipe curl directly into tar — no intermediate file, but cannot resume on failure. Only use when you truly cannot attach a temporary volume:
     ```bash
-    nohup bash -c "\
-      curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest && \
-      tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/ && \
-      rm -f $IOTEX_HOME/data.tar.gz && \
-      echo DONE > $IOTEX_HOME/snapshot.status \
-    " > $IOTEX_HOME/snapshot.log 2>&1 &
+    apt-get install -y pigz
+    mkdir -p $IOTEX_HOME/data
+    # No resume — restarts from scratch on failure
+    ATTEMPT=0; MAX=5
+    until [ $ATTEMPT -ge $MAX ]; do
+      ATTEMPT=$((ATTEMPT + 1)); echo "Attempt $ATTEMPT/$MAX"
+      rm -rf $IOTEX_HOME/data/*
+      curl -L -s --retry 10 --retry-delay 5 --speed-limit 100000 --speed-time 60 \
+        https://t.iotex.me/mainnet-data-snapshot-core-latest | pigz -d | tar -xf - -C $IOTEX_HOME/data/ && break
+      echo "Failed, retrying in 30s..."; sleep 30
+    done
     ```
-  - If the partition cannot hold both the compressed and extracted data, use stream extraction. If it cannot hold even the extracted data, the disk is too small — warn the user.
-- **Disk space:** always verify the current snapshot size from the URL before proceeding. Ensure the target partition has enough free space plus growth headroom. If the target partition is too small, suggest the user resize the disk or pick a larger volume before proceeding.
+- **Disk space:** always verify the current snapshot size from the URL before proceeding. Ensure the target partition has enough free space plus growth headroom. If the main disk can't hold both the compressed and extracted data, attach a temporary volume for the download — it only needs to hold the compressed file and can be deleted after extraction. If the target partition is too small even for extracted data, suggest the user resize the disk before proceeding.
 
 ## Upgrade
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -52,7 +52,11 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 ### Key things to know
 
 - **Always use `--snapshot` for fresh installs.** Without it, the node tries to sync from genesis using an Ethereum RPC endpoint. The default Infura key in config.yaml is expired, so the node will crash with `401 Unauthorized: account disabled`.
-- **`externalHost` must be IPv4.** The script auto-detects via `curl ip.sb`, which may return IPv6 on dual-stack servers. The p2p layer does not handle IPv6. Fix with: `curl -4 ip.sb` and update `$IOTEX_HOME/etc/config.yaml`.
+- **Fresh install in `--auto` mode** now works without interactive prompts:
+  - `externalHost` is auto-detected via `curl -4 ip.sb` (forced IPv4 — p2p layer does not handle IPv6).
+  - A random `producerPrivKey` is auto-generated as a temporary operator wallet.
+  - After install, ask the user: "A temporary operator key was generated. Do you want to fund this wallet for staking, or replace it with an existing key in `$IOTEX_HOME/etc/config.yaml`?"
+- **`externalHost` must be IPv4.** The script now uses `curl -4 ip.sb` by default. If the detected IP is wrong, update `$IOTEX_HOME/etc/config.yaml` and restart.
 - **Snapshot size analysis:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04). These sizes grow over time — always verify by checking the URL as shown above.
   - **File download + extract (recommended):** Download the tarball first with resume support, then extract. This is more reliable than streaming for large files — any network interruption resumes from where it left off instead of restarting. If the main disk can't hold both compressed + extracted data, use a temporary volume for the download:
     ```bash

--- a/AGENT.md
+++ b/AGENT.md
@@ -82,7 +82,18 @@ See the [main README](README.md#agent-upgrade) for all available flags.
     pigz -dc $DOWNLOAD_DIR/snapshot.tar.gz | tar -xf - -C $IOTEX_HOME/data/
     rm -f $DOWNLOAD_DIR/snapshot.tar.gz
     ```
-    For even faster downloads, use `aria2c -x16 -s16` instead of curl (16 parallel connections). aria2c also supports resume via `--continue=true`.
+    **Highly recommended: use `aria2c` instead of curl** — 5x to 15x faster in practice (measured ~275 MB/s with aria2c vs ~17 MB/s with single-connection curl). It splits the download across multiple parallel connections and also supports resume:
+    ```bash
+    apt-get install -y aria2 pigz
+    mkdir -p $IOTEX_HOME/data
+    DOWNLOAD_DIR=$IOTEX_HOME  # or /mnt/volume if main disk can't hold both
+    aria2c -x 16 -s 16 -k 10M --continue=true \
+      --max-tries=20 --retry-wait=10 \
+      -o snapshot.tar.gz -d $DOWNLOAD_DIR \
+      https://t.iotex.me/mainnet-data-snapshot-core-latest
+    pigz -dc $DOWNLOAD_DIR/snapshot.tar.gz | tar -xf - -C $IOTEX_HOME/data/
+    rm -f $DOWNLOAD_DIR/snapshot.tar.gz
+    ```
   - **Stream extraction (fallback — only when disk is very constrained):** Pipe curl directly into tar — no intermediate file, but cannot resume on failure. Only use when you truly cannot attach a temporary volume:
     ```bash
     apt-get install -y pigz

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -283,6 +283,17 @@ function stopAndRemoveContainer() {
 }
 
 function determineExtIp() {
+    # Check if an existing config already has externalHost
+    if [ -f "${IOTEX_HOME}/etc/config.yaml" ];then
+        local existingIp=$(grep '^  externalHost:' ${IOTEX_HOME}/etc/config.yaml 2>/dev/null | awk -F': ' '{print $2}' | tr -d ' "')
+        if [ -n "$existingIp" ];then
+            echo "Using existing externalHost from config.yaml: $existingIp"
+            ip="$existingIp"
+            externalHost="externalHost: $ip"
+            return
+        fi
+    fi
+
     # Force IPv4 — p2p layer does not handle IPv6
     findip=$(curl -4 -Ss ip.sb)
     if [ $_AUTO_ -eq 1 ];then
@@ -295,6 +306,17 @@ function determineExtIp() {
 }
 
 function determinPrivKey() {
+    # Check if an existing config already has a producerPrivKey
+    if [ -f "${IOTEX_HOME}/etc/config.yaml" ];then
+        local existingKey=$(grep '^  producerPrivKey:' ${IOTEX_HOME}/etc/config.yaml 2>/dev/null | awk -F': ' '{print $2}' | tr -d ' "')
+        if [ -n "$existingKey" ];then
+            echo "Using existing producerPrivKey from config.yaml"
+            privKey="$existingKey"
+            producerPrivKey="producerPrivKey: $privKey"
+            return
+        fi
+    fi
+
     if [ $_AUTO_ -eq 1 ];then
         # Auto-generate a random private key as temp operator wallet
         privKey=$(openssl rand -hex 32)
@@ -310,6 +332,16 @@ function determinPrivKey() {
 }
 
 function determineAdminPort() {
+    # Check if an existing config already has adminPort
+    if [ -f "${IOTEX_HOME}/etc/config.yaml" ];then
+        local existingPort=$(grep '^  httpAdminPort:' ${IOTEX_HOME}/etc/config.yaml 2>/dev/null | awk -F':' '{print $2}' | tr -d ' ')
+        if [ -n "$existingPort" ];then
+            echo "Using existing adminPort from config.yaml: $existingPort"
+            adminPort="$existingPort"
+            return
+        fi
+    fi
+
     if [ $_AUTO_ -eq 1 ];then
         return
     fi

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -283,21 +283,36 @@ function stopAndRemoveContainer() {
 }
 
 function determineExtIp() {
-    findip=$(curl -Ss ip.sb)
-    read -p "SET YOUR EXTERNAL IP HERE [$findip]: " inputip
-    ip=${inputip:-$findip}
+    # Force IPv4 — p2p layer does not handle IPv6
+    findip=$(curl -4 -Ss ip.sb)
+    if [ $_AUTO_ -eq 1 ];then
+        ip=$findip
+    else
+        read -p "SET YOUR EXTERNAL IP HERE [$findip]: " inputip
+        ip=${inputip:-$findip}
+    fi
     externalHost="externalHost: $ip"
 }
 
 function determinPrivKey() {
-    echo "If you are a delegate, make sure producerPrivKey is the key for the operator address you have registered."
-    echo  "SET YOUR PRIVATE KEY HERE(e.g., 96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8)"
-    read -p ": " inputkey
-    privKey=${inputkey:-"96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8"}
+    if [ $_AUTO_ -eq 1 ];then
+        # Auto-generate a random private key as temp operator wallet
+        privKey=$(openssl rand -hex 32)
+        echo -e "${YELLOW}Auto-generated temporary operator key: $privKey${NC}"
+        echo -e "${YELLOW}To use your own key, update producerPrivKey in \$IOTEX_HOME/etc/config.yaml and restart.${NC}"
+    else
+        echo "If you are a delegate, make sure producerPrivKey is the key for the operator address you have registered."
+        echo  "SET YOUR PRIVATE KEY HERE(e.g., 96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8)"
+        read -p ": " inputkey
+        privKey=${inputkey:-"96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8"}
+    fi
     producerPrivKey="producerPrivKey: $privKey"
 }
 
 function determineAdminPort() {
+    if [ $_AUTO_ -eq 1 ];then
+        return
+    fi
     echo "Enable admin port for node management."
     read -p "SET ADMIN PORT (press Enter to skip, e.g., 9009): " inputport
     if [ -n "$inputport" ]; then
@@ -576,9 +591,11 @@ function main() {
         determineAdminPort
 
         echo -e "${YELLOW} ****** Install IoTeX Node  ***** ${NC}"
-        echo -e "${YELLOW} if installed, Confirm Input IOTEX_HOME directory $IOTEX_HOME True ${NC};"
         if [ $_AUTO_ -eq 0 ];then
+            echo -e "${YELLOW} if installed, Confirm Input IOTEX_HOME directory $IOTEX_HOME True ${NC};"
             read -p "[Ctrl + c exit!]; else Enter anykey ..." anykey
+        else
+            echo -e "${YELLOW} Installing to $IOTEX_HOME ${NC}"
         fi
 
         mkdir -p ${IOTEX_HOME}

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -295,12 +295,22 @@ function determineExtIp() {
     fi
 
     # Force IPv4 — p2p layer does not handle IPv6
-    findip=$(curl -4 -Ss ip.sb)
+    findip=$(curl -4 -Ss --max-time 10 ip.sb 2>/dev/null)
+    if [ -z "$findip" ];then
+        if [ $_AUTO_ -eq 1 ];then
+            echo -e "${RED}Error: Failed to detect external IPv4 address. Check network connectivity or set externalHost manually in \$IOTEX_HOME/etc/config.yaml.${NC}"
+            exit 1
+        fi
+    fi
     if [ $_AUTO_ -eq 1 ];then
         ip=$findip
     else
         read -p "SET YOUR EXTERNAL IP HERE [$findip]: " inputip
         ip=${inputip:-$findip}
+    fi
+    if [ -z "$ip" ];then
+        echo -e "${RED}Error: externalHost cannot be empty.${NC}"
+        exit 1
     fi
     externalHost="externalHost: $ip"
 }
@@ -319,7 +329,15 @@ function determinPrivKey() {
 
     if [ $_AUTO_ -eq 1 ];then
         # Auto-generate a random private key as temp operator wallet
+        if ! command -v openssl &>/dev/null; then
+            echo -e "${RED}Error: openssl is required to generate a private key. Install it or provide producerPrivKey in \$IOTEX_HOME/etc/config.yaml.${NC}"
+            exit 1
+        fi
         privKey=$(openssl rand -hex 32)
+        if [ $? -ne 0 ] || [ -z "$privKey" ] || [ ${#privKey} -ne 64 ];then
+            echo -e "${RED}Error: Failed to generate private key via openssl.${NC}"
+            exit 1
+        fi
         echo -e "${YELLOW}Auto-generated temporary operator key: $privKey${NC}"
         echo -e "${YELLOW}To use your own key, update producerPrivKey in \$IOTEX_HOME/etc/config.yaml and restart.${NC}"
     else

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -295,12 +295,14 @@ function determineExtIp() {
     fi
 
     # Force IPv4 — p2p layer does not handle IPv6
-    findip=$(curl -4 -Ss --max-time 10 ip.sb 2>/dev/null)
-    if [ -z "$findip" ];then
-        if [ $_AUTO_ -eq 1 ];then
-            echo -e "${RED}Error: Failed to detect external IPv4 address. Check network connectivity or set externalHost manually in \$IOTEX_HOME/etc/config.yaml.${NC}"
-            exit 1
-        fi
+    findip=$(curl -4 -sSf --max-time 10 ip.sb 2>/dev/null | tr -d '[:space:]')
+    # Validate it looks like an IPv4 address
+    if ! echo "$findip" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$';then
+        findip=""
+    fi
+    if [ -z "$findip" ] && [ $_AUTO_ -eq 1 ];then
+        echo -e "${RED}Error: Failed to detect external IPv4 address. Check network connectivity or set externalHost manually in \$IOTEX_HOME/etc/config.yaml.${NC}"
+        exit 1
     fi
     if [ $_AUTO_ -eq 1 ];then
         ip=$findip
@@ -630,8 +632,10 @@ function main() {
     fi
 
     # Need update or install
+    # Upgrade requires both chain.db AND config.yaml — if data was pre-loaded
+    # (e.g. snapshot extracted manually) but no config exists, treat as fresh install
     _IS_UPGRADE_=0
-    if [ -f "${IOTEX_HOME}/data/chain.db" ];then
+    if [ -f "${IOTEX_HOME}/data/chain.db" ] && [ -f "${IOTEX_HOME}/etc/config.yaml" ];then
         _IS_UPGRADE_=1
         # Backup config while node is still running
         backupOldConfig


### PR DESCRIPTION
## Summary

Improvements to AGENT.md and the auto-mode install flow based on real-world testing:

- **Download**: Recommend aria2c (5-15x faster than curl single-connection — measured 275 MB/s vs 17 MB/s)
- **Clearer install options** (Option A: `--snapshot`, Option B: manual download)
- **Auto-mode fresh install fixes**:
  - Auto-detect IPv4 (force `curl -4`), validate IP format before writing config
  - Auto-generate random `producerPrivKey` if no existing config has one
  - Fail fast if openssl missing
  - Reuse existing pk/ip/port from config.yaml if present
  - Treat `chain.db` without `config.yaml` as fresh install (not upgrade)
  - Skip interactive prompts (admin port, install confirmation)

## Test plan
- [x] Fresh install with pre-extracted snapshot on q-iotex-node4 (Netcup Debian 13)
- [x] Fresh install with `--snapshot` on q-iotex-node3 (Hetzner Debian 12)
- [x] aria2c tested at 275 MB/s on Netcup RS