### PR TITLE
prepare testnet release for v2.4.0-rc2

### DIFF
--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.3.8
+- 测试网：v2.4.0-rc2
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.3.8
+docker pull iotex/iotex-core:v2.4.0-rc2
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -89,7 +89,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.3.8 \
+        iotex/iotex-core:v2.4.0-rc2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -107,7 +107,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.3.8 \
+        iotex/iotex-core:v2.4.0-rc2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -127,7 +127,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.3.8
+git checkout v2.4.0-rc2
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.3.8
+- TestNet: v2.4.0-rc2
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.3.8
+docker pull iotex/iotex-core:v2.4.0-rc2
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -90,7 +90,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.3.8 \
+        iotex/iotex-core:v2.4.0-rc2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.3.8 \
+        iotex/iotex-core:v2.4.0-rc2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -131,7 +131,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.3.8
+git checkout v2.4.0-rc2
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/changelog/v2.4.0-release-note.md
+++ b/changelog/v2.4.0-release-note.md
@@ -2,29 +2,51 @@
 
 ## Summary
 
-v2.4.0 is a **mandatory** release introducing the **Yap hardfork**, which enables Prague/Pectra EVM upgrades (including EIP-7702 SetCodeTx) and the candidate exit queue mechanism.
+v2.4.0 is a **mandatory** release. It activates the **Yap hardfork**, which brings the Pectra EVM upgrade (IIP-60) and the candidate exit queue mechanism to IoTeX.
 
 ## Changes
 
-### Feat: Yap Hardfork
+### Feat: Pectra EVM Upgrade (IIP-60)
 
-Activates at `yapHeight`. Replaces the previous `toBeEnabled` feature-gate pattern with a named hardfork. After Yap height:
+Implements four EIPs from the Ethereum Pectra upgrade. All features are activated at `yapHeight`.
 
-- Prague EVM rules are active (Pectra upgrade)
-- EIP-7702 SetCodeTx is enabled
-- Candidate exit queue is enforced
+#### EIP-7702: Set EOA Account Code
 
-### Feat: EIP-7702 SetCodeTx Support
+Introduces transaction type `0x04`, allowing an EOA to temporarily delegate its code execution to a smart contract by signing authorization tuples. Each authorization costs 12,500 gas; creating a new delegated account costs 25,000 gas. Delegated accounts are identified by the prefix `0xef0100 || address`. An abuse-prevention blacklist is applied on top of the standard Ethereum behavior.
 
-Implements the new Ethereum transaction type that allows an EOA to delegate its code execution to a contract. A blacklist mechanism prevents abuse. Gated behind `IsYap(height)`.
+#### EIP-7623: Increase Calldata Cost
+
+Raises the cost floor for data-heavy transactions to reduce the maximum possible block size. IoTeX sets `TX_COST_FLOOR_PER_TOKEN = 250` instead of Ethereum's value of 40, reflecting IoTeX's existing calldata baseline of 100 gas/byte versus Ethereum's 16 gas/byte, so that the relative cost increase is proportional.
+
+#### EIP-2935: Historical Block Hashes from State
+
+Stores the most recent 8,191 block hashes in a system contract at `0x0000F90827F1C53a10cb7A02335B175320002935`, extending hash accessibility beyond the standard 256-block EVM window. Useful for rollups and cross-chain applications that need to reference older block hashes.
+
+#### EIP-2537: BLS12-381 Precompiles
+
+Adds seven precompile operations at addresses `0x0b`–`0x11` for BLS12-381 curve operations, enabling efficient on-chain BLS signature verification with 120+ bits of security. Primarily benefits bridges and cross-chain protocols.
+
+---
 
 ### Feat: Candidate Exit Queue
 
-New `ScheduleCandidateDeactivation` action for graceful candidate deactivation. Introduces a queued exit mechanism (`CandidateDeactivate` / `CandidateActivate`) to replace the previous immediate-deactivation model. Affects staking protocol behavior.
+Replaces the previous immediate-deactivation model with a queue-based mechanism that enforces a notice period before a candidate can fully exit. The change is designed to give the network visibility into upcoming validator exits and prevent sudden stake withdrawals.
 
-### Feat: Prague / Pectra EVM Upgrade
+**Three-stage lifecycle:**
 
-Updated go-ethereum integration to v1.15.11 with Prague hard fork support. New geth tracer integrated. Receipt indexer enhanced.
+1. **Request** — The candidate owner calls `CandidateDeactivate(OpRequest)`. The self-stake bucket is locked (cannot be unstaked) and `DeactivatedAt` is set to a sentinel value indicating the exit has been requested.
+
+2. **Schedule** — At each epoch boundary, the protocol automatically scans for pending requests. At most one candidate is admitted per `ExitAdmissionInterval` epochs (default: 24 epochs). When admitted, the protocol generates a system `ScheduleCandidateDeactivation` action and sets `DeactivatedAt` to a specific future block height (`currentHeight + ExitAdmissionInterval × blocksPerEpoch`).
+
+3. **Confirm** — Once `currentHeight >= DeactivatedAt`, the candidate owner calls `CandidateDeactivate(OpConfirm)`. The self-stake is cleared (set to 0), the self-stake bucket index is removed from the candidate record, and the candidate is fully deactivated. The former self-stake bucket reverts to a regular vote bucket.
+
+**Key constraints:**
+- The self-stake bucket cannot be unstaked between request and confirmation.
+- Only one candidate per `ExitAdmissionInterval` epochs is admitted into the queue, preventing a rush of simultaneous exits.
+- The request cannot be cancelled once submitted.
+- `ScheduleCandidateDeactivation` is a zero-gas system action, not callable by users.
+
+---
 
 ### Fix
 

--- a/changelog/v2.4.0-release-note.md
+++ b/changelog/v2.4.0-release-note.md
@@ -1,0 +1,50 @@
+# v2.4.0 Release Note
+
+## Summary
+
+v2.4.0 is a **mandatory** release introducing the **Yap hardfork**, which enables Prague/Pectra EVM upgrades (including EIP-7702 SetCodeTx) and the candidate exit queue mechanism.
+
+## Changes
+
+### Feat: Yap Hardfork
+
+Activates at `yapHeight`. Replaces the previous `toBeEnabled` feature-gate pattern with a named hardfork. After Yap height:
+
+- Prague EVM rules are active (Pectra upgrade)
+- EIP-7702 SetCodeTx is enabled
+- Candidate exit queue is enforced
+
+### Feat: EIP-7702 SetCodeTx Support
+
+Implements the new Ethereum transaction type that allows an EOA to delegate its code execution to a contract. A blacklist mechanism prevents abuse. Gated behind `IsYap(height)`.
+
+### Feat: Candidate Exit Queue
+
+New `ScheduleCandidateDeactivation` action for graceful candidate deactivation. Introduces a queued exit mechanism (`CandidateDeactivate` / `CandidateActivate`) to replace the previous immediate-deactivation model. Affects staking protocol behavior.
+
+### Feat: Prague / Pectra EVM Upgrade
+
+Updated go-ethereum integration to v1.15.11 with Prague hard fork support. New geth tracer integrated. Receipt indexer enhanced.
+
+### Fix
+
+- Fixed `CandidateDeactivateOpConfirm` swallowing errors due to `:=` shadowing
+- Fixed `GetStorageRoot` polluting contract cache
+- Fixed contract staking index checking
+- Fixed candidate BLS public key update by operator
+- Fixed `CandsMap` not saved during full sync
+- Fixed WebSocket double-close
+
+## Upgrade Priority
+
+v2.4.0 is a **mandatory** release for all node types.
+
+| Node type  | Action        |
+| ---------- | ------------- |
+| Delegate   | **Mandatory** |
+| Fullnode   | **Mandatory** |
+| API node   | **Mandatory** |
+
+## Commits
+
+https://github.com/iotexproject/iotex-core/compare/v2.3.8...v2.4.0

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -38,6 +38,7 @@ blockchain:
   wakeHeight: 31943521
   xinguHeight: 36619201
   xinguBetaHeight: 36826561
+  yapHeight: 42793921
   numCandidateDelegates: 36
   numDelegates: 24
   numSubEpochs: 15

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -38,7 +38,7 @@ blockchain:
   wakeHeight: 31943521
   xinguHeight: 36619201
   xinguBetaHeight: 36826561
-  yapHeight: 42793921
+  yapHeight: 42819841
   numCandidateDelegates: 36
   numDelegates: 24
   numSubEpochs: 15

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.3.8
+docker pull iotex/iotex-core:v2.4.0-rc2
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0-rc2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
@@ -26,7 +26,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.3.8 \
+        iotex/iotex-core:v2.4.0-rc2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml


### PR DESCRIPTION
## Summary

- Bump testnet version strings to `v2.4.0-rc2` (README_testnet.md, README_CN_testnet.md, scripts/all_in_one_testnet.sh)
- Add `yapHeight: 42793921` to `genesis_testnet.yaml` for the Yap hardfork
- Add `changelog/v2.4.0-release-note.md` draft (Yap hardfork, EIP-7702, candidate exit queue, Prague/Pectra EVM)

Mainnet files remain at v2.3.8 — this PR covers testnet RC testing only (Phase 1 of the release flow).

## Test plan

- [ ] Deploy `iotex/iotex-core:v2.4.0-rc2` to 4 testnet clusters (testnet-gcp, testnet-gcp-2, testnet-london, testnet-sg)
- [ ] Monitor chain metrics and confirm Yap hardfork activates at height 42793921
- [ ] Verify EIP-7702 and candidate exit queue behavior on testnet

🤖 Generated with [Claude Code](https://claude.ai/claude-code)