### PR TITLE
config_testnet.yaml: update testnet bootnode port 4689 -> 4690

### DIFF
--- a/config_testnet.yaml
+++ b/config_testnet.yaml
@@ -1,9 +1,9 @@
 network:
   # externalHost: SET YOUR EXTERNAL IP HERE (e.g., 12.34.56.78)
-  externalPort: 4689
+  externalPort: 4690
   bootstrapNodes:
-    - /dns4/bootnode-0.testnet.iotex.one/tcp/4689/ipfs/12D3KooWFnaTYuLo8Mkbm3wzaWHtUuaxBRe24Uiopu15Wr5EhD3o
-    - /dns4/bootnode-1.testnet.iotex.one/tcp/4689/ipfs/12D3KooWS7hkdFozeUqriUxv7zw8Y6NCeV8E5HUbgmVkGJUv4jHS
+    - /dns4/bootnode-0.testnet.iotex.one/tcp/4690/ipfs/12D3KooWFnaTYuLo8Mkbm3wzaWHtUuaxBRe24Uiopu15Wr5EhD3o
+    - /dns4/bootnode-1.testnet.iotex.one/tcp/4690/ipfs/12D3KooWS7hkdFozeUqriUxv7zw8Y6NCeV8E5HUbgmVkGJUv4jHS
 
 chain:
   # producerPrivKey: SET YOUR PRIVATE KEY HERE (e.g., 96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8)


### PR DESCRIPTION
## Summary
- Update testnet `bootstrapNodes` entries (`bootnode-0.testnet.iotex.one`, `bootnode-1.testnet.iotex.one`) to use port 4690 instead of 4689.
- Update the default `externalPort` for testnet from 4689 to 4690.

## Test plan
- [ ] Start a testnet fullnode using the updated `config_testnet.yaml` and confirm it connects to the bootnodes on port 4690.
- [ ] Verify p2p peering and block sync on testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)