### PR TITLE
testnet: update P2P port 4689 → 4690 in docs and scripts

### DIFF
--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -83,7 +83,7 @@ curl -L -C - -o $IOTEX_HOME/poll.tar.gz https://storage.iotex.io/poll.testnet.ta
 
 ```
 docker run -d --restart on-failure --name iotex \
-        -p 4689:4689 \
+        -p 4690:4690 \
         -p 8080:8080 \
         -v=$IOTEX_HOME/data:/var/data:rw \
         -v=$IOTEX_HOME/log:/var/log:rw \
@@ -100,7 +100,7 @@ docker run -d --restart on-failure --name iotex \
 如果您还希望使节点成为[网关](#gateway)，可以处理用户的API请求，请改用以下命令：
 ```
 docker run -d --restart on-failure --name iotex \
-        -p 4689:4689 \
+        -p 4690:4690 \
         -p 14014:14014 \
         -p 8080:8080 \
         -v=$IOTEX_HOME/data:/var/data:rw \
@@ -114,7 +114,7 @@ docker run -d --restart on-failure --name iotex \
         -plugin=gateway
 ```
 
-7. 确保您的防火墙和负载均衡器（如果有）上的TCP端口4689, 8080（14014如果节点启用了网关）已打开。
+7. 确保您的防火墙和负载均衡器（如果有）上的TCP端口4690, 8080（14014如果节点启用了网关）已打开。
 
 ## <a name="testnet_native"/>不使用Docker加入测试网
 
@@ -158,7 +158,7 @@ nohup $IOTEX_HOME/iotex-server \
         -plugin=gateway &
 ```
 
-6. 确保您的防火墙和负载均衡器（如果有）上的TCP端口4689, 8080（14014如果节点启用了网关）已打开。
+6. 确保您的防火墙和负载均衡器（如果有）上的TCP端口4690, 8080（14014如果节点启用了网关）已打开。
 
 ## <a name="ioctl"/>与区块链交互
 

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -84,7 +84,7 @@ curl -L -C - -o $IOTEX_HOME/poll.tar.gz https://storage.iotex.io/poll.testnet.ta
 
 ```
 docker run -d --restart on-failure --name iotex \
-        -p 4689:4689 \
+        -p 4690:4690 \
         -p 8080:8080 \
         -v=$IOTEX_HOME/data:/var/data:rw \
         -v=$IOTEX_HOME/log:/var/log:rw \
@@ -102,7 +102,7 @@ If you want to also make your node be a [gateway](#gateway), which could process
 
 ```
 docker run -d --restart on-failure --name iotex \
-        -p 4689:4689 \
+        -p 4690:4690 \
         -p 14014:14014 \
         -p 15014:15014 \
         -p 8080:8080 \
@@ -117,7 +117,7 @@ docker run -d --restart on-failure --name iotex \
         -plugin=gateway
 ```
 
-7. Make sure TCP ports 4689, 8080 (also 14014 if used) are open on your firewall and load balancer (if any).
+7. Make sure TCP ports 4690, 8080 (also 14014 if used) are open on your firewall and load balancer (if any).
 
 ## <a name="testnet_native"/>Join Testnet without using Docker
 This is not the preferred way to start an IoTeX node
@@ -167,7 +167,7 @@ nohup $IOTEX_HOME/iotex-server \
         -plugin=gateway &
 ```
 
-6. Make sure TCP ports 4689, 8080 (also 14014 if used) are open on your firewall and load balancer (if any).
+6. Make sure TCP ports 4690, 8080 (also 14014 if used) are open on your firewall and load balancer (if any).
 
 ## <a name="ioctl"/>Interact with Blockchain
 

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -20,7 +20,7 @@ curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot
 tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 
 docker run -d --restart on-failure --name iotex \
-        -p 4689:4689 \
+        -p 4690:4690 \
         -p 8080:8080 \
         -v=$IOTEX_HOME/data:/var/data:rw \
         -v=$IOTEX_HOME/log:/var/log:rw \

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -67,11 +67,13 @@ function setVar() {
 function processParam() {
     _ENV_=mainnet
     _GREP_STRING_=MainNet
+    _P2P_PORT_=4689
     for arg in "$@"; do
         case "$arg" in
             testnet)
                 _ENV_=testnet
                 _GREP_STRING_=TestNet
+                _P2P_PORT_=4690
                 ;;
             plugin=gateway)
                 _PLUGINS_=gateway
@@ -195,6 +197,10 @@ function preDockerCompose() {
     downloadFile "https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/monitor/docker-compose.yml.gateway" "$IOTEX_MONITOR_HOME/docker-compose.yml.gateway"
     downloadFile "https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/monitor/docker-compose.yml" "$IOTEX_MONITOR_HOME/docker-compose.yml.default"
     downloadFile "https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/monitor/.env" "$IOTEX_MONITOR_HOME/.env"
+    if [ "${_P2P_PORT_}" != "4689" ]; then
+        sed -i "s/- 4689:4689/- ${_P2P_PORT_}:${_P2P_PORT_}/g" "$IOTEX_MONITOR_HOME/docker-compose.yml.gateway"
+        sed -i "s/- 4689:4689/- ${_P2P_PORT_}:${_P2P_PORT_}/g" "$IOTEX_MONITOR_HOME/docker-compose.yml.default"
+    fi
 }
 
 function enableMonitor() {
@@ -388,9 +394,9 @@ function addAdminPortToCompose() {
         fi
         echo "Adding admin port mapping to docker-compose.yml"
         # Use awk for reliable cross-platform replacement with proper indentation
-        awk -v port="$adminPort" '{
+        awk -v port="$adminPort" -v p2pport="${_P2P_PORT_}" '{
             print
-            if (/^[[:space:]]*- 4689:4689/) {
+            if ($0 ~ ("^[[:space:]]*- " p2pport ":" p2pport)) {
                 printf "      - %s:%s\n", port, port
             }
         }' "$composeFile" > "${composeFile}.tmp" && mv "${composeFile}.tmp" "$composeFile"

--- a/scripts/update_silence.sh
+++ b/scripts/update_silence.sh
@@ -15,6 +15,13 @@ NC='\033[0m' # No Color
 #echo -e "ENV _GREP_STRING_ must be set."
 [ $_GREP_STRING_ ] || exit 2
 
+# Derive P2P port from environment (testnet uses 4690, mainnet uses 4689)
+if [ "${_ENV_}" = "testnet" ]; then
+    _P2P_PORT_=4690
+else
+    _P2P_PORT_=4689
+fi
+
 pushd () {
     command pushd "$@" > /dev/null
 }
@@ -163,9 +170,9 @@ function addAdminPortToCompose() {
         # Check if port mapping already exists
         if ! grep -q "${adminPort}:${adminPort}" $composeFile; then
             # Use awk for reliable cross-platform replacement with proper indentation
-            awk -v port="$adminPort" '{
+            awk -v port="$adminPort" -v p2pport="${_P2P_PORT_}" '{
                 print
-                if (/^[[:space:]]*- 4689:4689/) {
+                if ($0 ~ ("^[[:space:]]*- " p2pport ":" p2pport)) {
                     printf "      - %s:%s\n", port, port
                 }
             }' "$composeFile" > "${composeFile}.tmp" && mv "${composeFile}.tmp" "$composeFile"


### PR DESCRIPTION
## Summary

Follow-up to the `config_testnet.yaml` bootnode port change (4689 → 4690). Updates all testnet-facing documentation and automation scripts to use the new default P2P port.

**Changed files:**
- `README_testnet.md` / `README_CN_testnet.md` — `docker run -p` mappings and firewall port instructions (4 locations each)
- `scripts/all_in_one_testnet.sh` — `docker run -p` mapping
- `scripts/setup_fullnode.sh` — introduce `_P2P_PORT_` variable (4689 for mainnet, 4690 for testnet); patch monitor `docker-compose` templates after download when running testnet; use variable as awk anchor in `addAdminPortToCompose`
- `scripts/update_silence.sh` — derive `_P2P_PORT_` from `_ENV_`; same awk anchor fix

Monitor templates (`monitor/docker-compose.yml`, `docker-compose.yml.gateway`) remain at 4689 (mainnet default) and are patched in-place by the script when running for testnet.

## Test plan

- [ ] Verify `setup_fullnode.sh testnet` sets `_P2P_PORT_=4690` and patches downloaded docker-compose templates
- [ ] Verify `setup_fullnode.sh` (no arg / mainnet) still sets `_P2P_PORT_=4689` and templates are unchanged
- [ ] Verify README docker run commands show `-p 4690:4690` for testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)