### PR TITLE
release v2.4.1: bump image refs, add changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.0**. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.1**. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.4.0`)
+1. Update `version` references in README.md (search for `v2.4.1`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.0
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.1
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Here are the software versions we use:
 
-- MainNet: v2.4.0
+- MainNet: v2.4.1
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +33,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +48,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -94,7 +94,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -115,7 +115,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -139,7 +139,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.0
+git checkout v2.4.1
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -301,7 +301,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.4.0` | Target version (default: latest release) |
+| `--version=v2.4.1` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -315,7 +315,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.0
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.1
 ```
 
 **Notes:**

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.4.0
+- 主网：v2.4.1
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +32,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +47,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -92,7 +92,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -130,7 +130,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.0
+git checkout v2.4.1
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.4.0
+- 测试网：v2.4.1
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -89,7 +89,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -107,7 +107,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -127,7 +127,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.0
+git checkout v2.4.1
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.4.0
+- TestNet: v2.4.1
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -90,7 +90,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -131,7 +131,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.0
+git checkout v2.4.1
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/archive-node.md
+++ b/archive-node.md
@@ -146,7 +146,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/iotex-archive/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -189,7 +189,7 @@ git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
 
 #checkout the code branch for archive node
-git checkout v2.4.0
+git checkout v2.4.1
 
 #build binary
 make build

--- a/changelog/v2.4.1-release-note.md
+++ b/changelog/v2.4.1-release-note.md
@@ -1,0 +1,74 @@
+# v2.4.1 Release Note
+
+## Summary
+
+v2.4.1 is a **mandatory** follow-up patch to v2.4.0 fixing bugs in the **candidate exit queue** introduced by the Yap hardfork. All changes are scoped to the staking package; no genesis or config schema changes.
+
+The most severe of these — a storage-layer bug that panics archive nodes the first time `ScheduleCandidateDeactivation` runs after Yap activation — requires every archive operator to upgrade. The remaining fixes restore Web3 access to the exit queue, correct dropped event data, and clean up post-confirmation state.
+
+## Changes
+
+### Fix: archive nodes panic on the Schedule block (#4827)
+
+`*lastExitEpoch` is stored in the `CandsMap` namespace, which is registered with `WithKVListOption` on archive-enabled nodes. The erigon `kvListStorage` path type-asserts every object to `kvListContainer`, but `*lastExitEpoch` didn't implement `Encodes` / `Decodes`. As a result, when `handleScheduleCandidateDeactivation` first wrote the value, archive nodes panicked with:
+
+```
+object of type *staking.lastExitEpoch does not supported
+```
+
+and could not validate the block, looping on restart. The fix adds `Encodes` / `Decodes` that collapse the single value into a one-entry kv list (empty suffix key, `PrimaryData` = the existing proto-encoded epoch), keeping the on-disk shape identical to the non-archive path.
+
+### Fix: Confirm op of CandidateDeactivate callable via Web3 (#4828)
+
+Two gaps prevented external wallets (MetaMask, RainbowKit) from submitting the Confirm step of the exit queue:
+
+1. `native_staking_contract_abi.json` was missing the `confirmCandidateDeactivation` method entry. The Go `init()` referenced `confirmCandidateDeactivationMethod` but it was never loaded, so its selector ID stayed zero-valued and the corresponding cases in the ABI parser were unreachable.
+2. `NewCandidateDeactivateFromABIBinary` rejected payloads with `len(data) <= 4`. Both `requestCandidateDeactivation` and `confirmCandidateDeactivation` take no arguments, so a valid call is exactly 4 bytes (selector only). The guard is loosened to `len(data) < 4`.
+
+Native gRPC submission of the Confirm op kept working because it goes through the proto path, not the ABI parser — which masked this bug during local testing.
+
+### Feat: `candidateDeactivation` view method (#4829)
+
+New Web3 view exposes the exit-queue state for a candidate without appending fields to `candidateByAddressV4`:
+
+```
+candidateDeactivation(address)
+  → (bool requested, uint64 scheduledAtBlock)
+```
+
+| `requested` | `scheduledAtBlock` | Meaning |
+| ----------- | ------------------ | ------- |
+| `false`     | `0`                | No exit in flight |
+| `true`      | `0`                | Requested; chain has not yet scheduled |
+| `true`      | `N`                | Scheduled; confirmable when `currentHeight >= N` |
+
+The internal `MaxUint64` sentinel (used for "requested-but-not-scheduled") is unpacked here so clients don't have to know the in-chain magic value.
+
+Going forward, bundled struct getters (`candidateByAddressV4` etc.) are treated as frozen — new per-feature state gets its own focused selector rather than a V5 bump. Clients combine them via multicall.
+
+### Fix: clear `DeactivatedAt` after confirming candidate exit
+
+`csm.deactivate` only zeroed `SelfStake` and `SelfStakeBucketIdx` after a Confirm landed, leaving `Candidate.DeactivatedAt` at the previous scheduled block height. The `candidateDeactivation` view derived `requested` / `scheduledAtBlock` from that field, so a re-staked candidate looked permanently confirmable (iotex-hub jumped straight to "Confirm Exit" on the next view, even with no new request in flight). `DeactivatedAt` is now reset to `0` alongside the other self-stake fields so the request → schedule → confirm cycle starts fresh on the next round.
+
+### Fix: emit non-indexed event args on candidate deactivation
+
+`handleCandidateDeactivate` and `handleScheduleCandidateDeactivation` built their receipt logs via a struct literal that routed through `receiptLog.Build`'s legacy single-log branch, which only copies `r.topics` and silently drops `r.data`. The `CandidateDeactivationScheduled` event declares `blockNumber` as non-indexed in the ABI, so its encoded value belongs in `Data` — without this fix, frontends saw the event fire but could not read the scheduled exit height. Both handlers now route through `AddEvent`, matching `handleCandidateRegister`.
+
+### Refactor: split `newReceiptLog` into legacy + events constructors
+
+No behavior change. `receiptLog` previously served two emission shapes (legacy `topics + data` vs `events`) through a single constructor, making the distinction invisible at the call site. Split into `newReceiptLog(addr)` (events-only, for new code) and `newReceiptLogLegacy(addr, topic, postFairbank)` (pre-events shape). The 13 production callers move to the legacy constructor; the deactivate handlers use the new events constructor. Doc comments warn against mixing `AddEvent` with the legacy fields.
+
+## Upgrade Priority
+
+v2.4.1 is a **mandatory** release for all node types.
+
+| Node type     | Action        |
+| ------------- | ------------- |
+| Archive node  | **Mandatory** |
+| Delegate      | **Mandatory** |
+| Fullnode      | **Mandatory** |
+| API node      | **Mandatory** |
+
+## Commits
+
+https://github.com/iotexproject/iotex-core/compare/v2.4.0...v2.4.1

--- a/changelog/v2.4.1-release-note.md
+++ b/changelog/v2.4.1-release-note.md
@@ -2,61 +2,18 @@
 
 ## Summary
 
-v2.4.1 is a **mandatory** follow-up patch to v2.4.0 fixing bugs in the **candidate exit queue** introduced by the Yap hardfork. All changes are scoped to the staking package; no genesis or config schema changes.
+v2.4.1 is a **mandatory** follow-up patch to v2.4.0 fixing bugs in the candidate exit queue introduced by the Yap hardfork. All changes are scoped to the staking package; no genesis or config schema changes.
 
-The most severe of these — a storage-layer bug that panics archive nodes the first time `ScheduleCandidateDeactivation` runs after Yap activation — requires every archive operator to upgrade. The remaining fixes restore Web3 access to the exit queue, correct dropped event data, and clean up post-confirmation state.
+The headline fix prevents archive nodes from panicking the first time `ScheduleCandidateDeactivation` runs after Yap activation. The remaining fixes restore Web3 access to the exit queue and correct dropped event data.
 
 ## Changes
 
-### Fix: archive nodes panic on the Schedule block (#4827)
-
-`*lastExitEpoch` is stored in the `CandsMap` namespace, which is registered with `WithKVListOption` on archive-enabled nodes. The erigon `kvListStorage` path type-asserts every object to `kvListContainer`, but `*lastExitEpoch` didn't implement `Encodes` / `Decodes`. As a result, when `handleScheduleCandidateDeactivation` first wrote the value, archive nodes panicked with:
-
-```
-object of type *staking.lastExitEpoch does not supported
-```
-
-and could not validate the block, looping on restart. The fix adds `Encodes` / `Decodes` that collapse the single value into a one-entry kv list (empty suffix key, `PrimaryData` = the existing proto-encoded epoch), keeping the on-disk shape identical to the non-archive path.
-
-### Fix: Confirm op of CandidateDeactivate callable via Web3 (#4828)
-
-Two gaps prevented external wallets (MetaMask, RainbowKit) from submitting the Confirm step of the exit queue:
-
-1. `native_staking_contract_abi.json` was missing the `confirmCandidateDeactivation` method entry. The Go `init()` referenced `confirmCandidateDeactivationMethod` but it was never loaded, so its selector ID stayed zero-valued and the corresponding cases in the ABI parser were unreachable.
-2. `NewCandidateDeactivateFromABIBinary` rejected payloads with `len(data) <= 4`. Both `requestCandidateDeactivation` and `confirmCandidateDeactivation` take no arguments, so a valid call is exactly 4 bytes (selector only). The guard is loosened to `len(data) < 4`.
-
-Native gRPC submission of the Confirm op kept working because it goes through the proto path, not the ABI parser — which masked this bug during local testing.
-
-### Feat: `candidateDeactivation` view method (#4829)
-
-New Web3 view exposes the exit-queue state for a candidate without appending fields to `candidateByAddressV4`:
-
-```
-candidateDeactivation(address)
-  → (bool requested, uint64 scheduledAtBlock)
-```
-
-| `requested` | `scheduledAtBlock` | Meaning |
-| ----------- | ------------------ | ------- |
-| `false`     | `0`                | No exit in flight |
-| `true`      | `0`                | Requested; chain has not yet scheduled |
-| `true`      | `N`                | Scheduled; confirmable when `currentHeight >= N` |
-
-The internal `MaxUint64` sentinel (used for "requested-but-not-scheduled") is unpacked here so clients don't have to know the in-chain magic value.
-
-Going forward, bundled struct getters (`candidateByAddressV4` etc.) are treated as frozen — new per-feature state gets its own focused selector rather than a V5 bump. Clients combine them via multicall.
-
-### Fix: clear `DeactivatedAt` after confirming candidate exit
-
-`csm.deactivate` only zeroed `SelfStake` and `SelfStakeBucketIdx` after a Confirm landed, leaving `Candidate.DeactivatedAt` at the previous scheduled block height. The `candidateDeactivation` view derived `requested` / `scheduledAtBlock` from that field, so a re-staked candidate looked permanently confirmable (iotex-hub jumped straight to "Confirm Exit" on the next view, even with no new request in flight). `DeactivatedAt` is now reset to `0` alongside the other self-stake fields so the request → schedule → confirm cycle starts fresh on the next round.
-
-### Fix: emit non-indexed event args on candidate deactivation
-
-`handleCandidateDeactivate` and `handleScheduleCandidateDeactivation` built their receipt logs via a struct literal that routed through `receiptLog.Build`'s legacy single-log branch, which only copies `r.topics` and silently drops `r.data`. The `CandidateDeactivationScheduled` event declares `blockNumber` as non-indexed in the ABI, so its encoded value belongs in `Data` — without this fix, frontends saw the event fire but could not read the scheduled exit height. Both handlers now route through `AddEvent`, matching `handleCandidateRegister`.
-
-### Refactor: split `newReceiptLog` into legacy + events constructors
-
-No behavior change. `receiptLog` previously served two emission shapes (legacy `topics + data` vs `events`) through a single constructor, making the distinction invisible at the call site. Split into `newReceiptLog(addr)` (events-only, for new code) and `newReceiptLogLegacy(addr, topic, postFairbank)` (pre-events shape). The 13 production callers move to the legacy constructor; the deactivate handlers use the new events constructor. Doc comments warn against mixing `AddEvent` with the legacy fields.
+- **Fix: archive nodes panic on the Schedule block** (#4827) — `*lastExitEpoch` now implements `kvListContainer` so it can be stored under the `CandsMap` namespace via erigon's `kvListStorage`. Without this, archive-enabled nodes panicked with `object of type *staking.lastExitEpoch does not supported` and entered a restart loop.
+- **Fix: Confirm op callable via Web3** (#4828) — registers the missing `confirmCandidateDeactivation` ABI method and loosens the zero-arg length guard (`len(data) <= 4` → `< 4`). Native gRPC was unaffected, which masked the bug during local testing.
+- **Feat: `candidateDeactivation` view method** (#4829) — `candidateDeactivation(address) → (bool requested, uint64 scheduledAtBlock)`. Exposes exit-queue state to dApps and unpacks the internal `MaxUint64` sentinel for "requested-but-not-scheduled".
+- **Fix: clear `DeactivatedAt` after Confirm** — prevents frontends like iotex-hub from showing "Confirm Exit" prematurely on a re-staked candidate.
+- **Fix: emit non-indexed event args on candidate deactivation** — `CandidateDeactivationScheduled.blockNumber` was being dropped because the handlers used the legacy receipt-log path. Both deactivation handlers now route through `AddEvent`.
+- **Refactor: split `newReceiptLog` into legacy + events constructors** — no behavior change; prevents the event-args bug above from recurring.
 
 ## Upgrade Priority
 

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
@@ -27,7 +27,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.0
+docker pull iotex/iotex-core:v2.4.1
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
@@ -26,7 +26,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.0 \
+        iotex/iotex-core:v2.4.1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml


### PR DESCRIPTION
## Summary

v2.4.1 is a mandatory follow-up patch to v2.4.0 fixing bugs in the candidate exit queue introduced by the Yap hardfork. All upstream changes are scoped to the staking package; no genesis or config schema changes.

- Bump all `v2.4.0` image / config / git-checkout references to `v2.4.1` across READMEs (EN + CN, mainnet + testnet), `archive-node.md`, and the `all_in_one_*.sh` scripts.
- Add `changelog/v2.4.1-release-note.md` covering the seven follow-up commits:
  - `fix(staking)` *lastExitEpoch* compatible with erigon kvListStorage (#4827) — **critical**, prevents archive-node panic on the first Schedule action after Yap activation.
  - `fix(staking)` make CandidateDeactivate Confirm op callable via Web3 (#4828) — registers the missing ABI selector and loosens the zero-arg `len(data)` guard so MetaMask / RainbowKit can submit Confirm.
  - `feat(staking)` add `candidateDeactivation` view method (#4829) — Web3 getter for exit-queue state without bumping `candidateByAddressV4`.
  - `fix(staking)` clear `DeactivatedAt` after confirming candidate exit.
  - `fix(staking)` emit non-indexed event args on candidate deactivation.
  - `refactor(staking)` split `newReceiptLog` into legacy + events constructors.
  - `test(staking)` align endorsement-revoke expectations with cleared `DeactivatedAt`.

Upstream compare: https://github.com/iotexproject/iotex-core/compare/v2.4.0...v2.4.1

## Test plan

- [ ] Docker image `iotex/iotex-core:v2.4.1` is published on Docker Hub before merge.
- [ ] `scripts/all_in_one_mainnet.sh` pulls and runs `iotex/iotex-core:v2.4.1` cleanly on a mainnet test box.
- [ ] `scripts/all_in_one_testnet.sh` pulls and runs `iotex/iotex-core:v2.4.1` cleanly on a testnet test box.
- [ ] `setup_fullnode.sh --auto --version=v2.4.1` upgrades an existing node from v2.4.0 → v2.4.1.
- [ ] Archive node setup per `archive-node.md` runs through the next `ScheduleCandidateDeactivation` without panic.
- [ ] Submit `confirmCandidateDeactivation` from MetaMask end-to-end on testnet.
- [ ] `candidateDeactivation(address)` Web3 view returns the expected three states (no exit / requested / scheduled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)