### PR TITLE
release v2.4.2: bump image and config refs, add changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.1**. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.2**. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.4.1`)
+1. Update `version` references in README.md (search for `v2.4.2`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.1
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.2
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Here are the software versions we use:
 
-- MainNet: v2.4.1
+- MainNet: v2.4.2
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +33,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +48,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -94,7 +94,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -115,7 +115,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -139,7 +139,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.1
+git checkout v2.4.2
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -301,7 +301,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.4.1` | Target version (default: latest release) |
+| `--version=v2.4.2` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -315,7 +315,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.1
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.2
 ```
 
 **Notes:**

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.4.1
+- 主网：v2.4.2
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +32,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +47,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -92,7 +92,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -130,7 +130,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.1
+git checkout v2.4.2
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.4.1
+- 测试网：v2.4.2
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -89,7 +89,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -107,7 +107,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -127,7 +127,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.1
+git checkout v2.4.2
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.4.1
+- TestNet: v2.4.2
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -90,7 +90,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -131,7 +131,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.1
+git checkout v2.4.2
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/archive-node.md
+++ b/archive-node.md
@@ -146,7 +146,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/iotex-archive/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -189,7 +189,7 @@ git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
 
 #checkout the code branch for archive node
-git checkout v2.4.1
+git checkout v2.4.2
 
 #build binary
 make build

--- a/changelog/v2.4.2-release-note.md
+++ b/changelog/v2.4.2-release-note.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-v2.4.2 is a **mandatory** security and stability patch release on top of v2.4.1. The mandatory portion is a set of HIGH-severity peer-reachable DoS fixes — five panic-prone deserialization paths, an unbounded action-sync flood vector, and an unauthenticated `/pause` endpoint that was bound to all interfaces. It also ships a hotfix for an api/delegate-node crash on the mint goroutine, two mempool hardening changes, hot rotation of producer keys, and several tooling additions (EIP-7702 in `ioctl`, the new `ioswarm` coordinator). No hardfork, no genesis change, no config schema change required for existing operators.
+v2.4.2 is a **recommended** security and stability patch release on top of v2.4.1. It hardens a set of panic-prone deserialization paths reachable from peer-controlled input, caps action-sync request fan-out, and binds the admin mux to the loopback interface only. It also ships a hotfix for an api/delegate-node crash on the mint goroutine, two mempool hardening changes, hot rotation of producer keys, and several tooling additions (EIP-7702 in `ioctl`, the new `ioswarm` coordinator). No hardfork, no genesis change, no config schema change required for existing operators.
 
 > **Operator-visible behavior change:** the HTTP admin mux (`/pause`, `/unpause`, `/producer-keys`, pprof) is now bound to `127.0.0.1` instead of `0.0.0.0`. Anything that was reaching the admin port from outside the host will break after upgrade — by design. Use an SSH tunnel or an authenticated reverse proxy on the host if you need remote access to `/producer-keys`.
 
@@ -39,14 +39,14 @@ v2.4.2 is a **mandatory** security and stability patch release on top of v2.4.1.
 
 ## Upgrade Priority
 
-v2.4.2 is **mandatory** for all node types because of the peer-reachable DoS fixes in #4844. Api/gateway nodes that were unable to mint blocks because of the `workingSetStoreWithSecondary` error, and delegates that have hit the post-Upernavik mint panic, should upgrade as soon as possible.
+v2.4.2 is **recommended** for all node types. Api/gateway nodes that were unable to mint blocks because of the `workingSetStoreWithSecondary` error, and delegates that have hit the post-Upernavik mint panic, should upgrade as soon as possible.
 
-| Node type     | Action          |
-| ------------- | --------------- |
-| Delegate      | **Mandatory**   |
-| Fullnode      | **Mandatory**   |
-| API node      | **Mandatory**   |
-| Archive node  | **Mandatory**   |
+| Node type     | Action            |
+| ------------- | ----------------- |
+| Delegate      | **Recommended**   |
+| Fullnode      | **Recommended**   |
+| API node      | **Recommended**   |
+| Archive node  | **Recommended**   |
 
 No genesis or config schema changes; v2.4.2 is Go-only and introduces no new activation heights.
 

--- a/changelog/v2.4.2-release-note.md
+++ b/changelog/v2.4.2-release-note.md
@@ -1,0 +1,36 @@
+# v2.4.2 Release Note
+
+## Summary
+
+v2.4.2 is a **recommended** patch release on top of v2.4.1. It ships a hotfix for an api/delegate-node crash path on the mint goroutine, two consensus/mempool hardening changes, hot rotation of producer keys, and several tooling additions (EIP-7702 in `ioctl`, the new `ioswarm` coordinator). No hardfork, no genesis change, no config schema change required for existing operators.
+
+## Changes
+
+### Fix
+
+- **Recover mint goroutine panics to keep the process alive** (#4840) — When block-sync committed a block while a draft mint was in flight, the trie's copy-on-write delete could remove a node the mint goroutine later traversed, surfacing as `db.ErrNotExist` inside EVM `SetState` and (with `panicUnrecoverableError` set after Upernavik) crashing `iotex-server` via `log.Panic`. The mint goroutine in `blockPreparer.prepare` now wraps the draft in a `defer`/`recover`, discards the panicked draft, and returns it as an error to the caller. The block-apply path (`PutBlock`) still panics on corruption to preserve the safety net there. Adds an `iotex_mint_panics_total` Prometheus counter and an error log with the panic value + stack. A follow-up will address the underlying race.
+- **Disable premint on api nodes** (#4839) — API nodes (those with `chain.historyIndexPath` set) wire a `workingSetStoreWithSecondary` whose `KVStore()` returns nil; the pre-mint path called `NewWorkingSet`, which requires `KVStore()`, and errored with `"KVStore() not supported in *workingSetStoreWithSecondary"`, blocking the api node from minting. The pre-mint step is now gated and turned off automatically when `historyIndexPath` is configured. With pre-mint off, mint goes through the default `newWorkingSet` path, which works correctly for api nodes.
+
+### Feat
+
+- **Hot producer-key updates** (#4816) — Adds an authenticated admin endpoint for rotating delegate signing keys without restarting the node. `PUT /producer-keys` replaces the full list; `PATCH /producer-keys` performs incremental `add_keys` / `remove_addresses` updates. Authentication is via the `IOTEX_ADMIN_TOKEN` environment variable; the endpoint **fails closed** if the variable is unset, so the admin port can be safely exposed only on a trusted interface. Request bodies are capped and reject unknown JSON fields. Operator addresses are emitted on rotation via an explicit log line ("Updated producer keys in memory") and in the heartbeat log.
+- **EIP-7702 `SetCode` tx support in `ioctl`** (#4837) — `ioctl action sign-auth` produces a signed EIP-7702 authorization (0x-hex RLP, compatible with `cast wallet sign-auth`-style tooling). `ioctl action transfer` and `ioctl contract invoke` gain an `--auth` flag that switches the action into a `SetCodeTx`. Non-legacy tx types are dispatched with TX_CONTAINER encoding (the chain's generic validator rejects IOTEX_PROTOBUF-encoded modern tx types). `--auth` is intentionally not registered on `contract deploy` since a `SetCodeTx` is always a CALL and the chain rejects a nil `to`.
+- **BundlePool hardening** (#4818) — Security hardening on top of the bundle pool (#4733): the broken sender-based `DeleteBundle` authorization is removed in favor of UUID as ownership token; a `maxLookahead` of 100 blocks prevents memory DoS from far-future target heights; a `maxSize` of 1000 caps total bundles; and bundle contents are restricted to `Transfer` / `Execution` / `txContainer` action types.
+- **Introduce `ioswarm` coordinator** — A new optional subsystem registered behind `ioswarm.enabled: false` by default in `config.yaml`. Existing nodes pick up the defaults transparently and require no action; see `ioswarm/README.md` in iotex-core for the design and operator notes for delegates who want to enable it.
+
+## Upgrade Priority
+
+v2.4.2 is **recommended** for all node types. Api/gateway nodes that were unable to mint blocks because of the `workingSetStoreWithSecondary` error, and delegates that have hit the post-Upernavik mint panic, should upgrade as soon as possible.
+
+| Node type     | Action            |
+| ------------- | ----------------- |
+| Delegate      | **Recommended**   |
+| Fullnode      | **Recommended**   |
+| API node      | **Recommended**   |
+| Archive node  | **Recommended**   |
+
+No genesis or config schema changes; v2.4.2 is Go-only and introduces no new activation heights.
+
+## Commits
+
+https://github.com/iotexproject/iotex-core/compare/v2.4.1...v2.4.2

--- a/changelog/v2.4.2-release-note.md
+++ b/changelog/v2.4.2-release-note.md
@@ -2,9 +2,24 @@
 
 ## Summary
 
-v2.4.2 is a **recommended** patch release on top of v2.4.1. It ships a hotfix for an api/delegate-node crash path on the mint goroutine, two consensus/mempool hardening changes, hot rotation of producer keys, and several tooling additions (EIP-7702 in `ioctl`, the new `ioswarm` coordinator). No hardfork, no genesis change, no config schema change required for existing operators.
+v2.4.2 is a **mandatory** security and stability patch release on top of v2.4.1. The mandatory portion is a set of HIGH-severity peer-reachable DoS fixes — five panic-prone deserialization paths, an unbounded action-sync flood vector, and an unauthenticated `/pause` endpoint that was bound to all interfaces. It also ships a hotfix for an api/delegate-node crash on the mint goroutine, two mempool hardening changes, hot rotation of producer keys, and several tooling additions (EIP-7702 in `ioctl`, the new `ioswarm` coordinator). No hardfork, no genesis change, no config schema change required for existing operators.
+
+> **Operator-visible behavior change:** the HTTP admin mux (`/pause`, `/unpause`, `/producer-keys`, pprof) is now bound to `127.0.0.1` instead of `0.0.0.0`. Anything that was reaching the admin port from outside the host will break after upgrade — by design. Use an SSH tunnel or an authenticated reverse proxy on the host if you need remote access to `/producer-keys`.
 
 ## Changes
+
+### Security
+
+- **Harden deserialization and message handlers against panics** (#4844) — Replaces panic-prone paths reachable from peer-controlled or untrusted input with explicit error returns:
+  - `action.envelope.LoadProto`: return `ErrInvalidAct` on unknown `TxType` instead of panicking on `TxType >= 5`.
+  - `evm.ExtractRevertMessage`: bound-check the `Error(string)` ABI payload; malformed revert payloads now invalidate the action instead of landing in the receipt as junk hex.
+  - `evm.StateDBAdapter.AddLog`: guard the in-contract-transfer topic check against empty topics.
+  - `chainservice.Filter` / `ReportFullness`: reject blocks with nil `Header` or nil `Header.Core` before dereferencing `Height`.
+  - `endorsement.Endorsement.LoadProto`: return an error on nil proto instead of panicking before signature/delegate verification.
+  - Three HIGH-severity peer-reachable attack vectors from the security audit are also addressed in the same PR:
+    - **nodeinfo**: `HandleNodeInfo` no longer dereferences `msg.Info` without a nil check — any peer could previously crash a node by broadcasting `NODE_INFO` with `Info=nil`.
+    - **actsync**: `RequestActionsFromNeighbors` now caps in-flight requests, closing an outbound-traffic flood vector.
+    - **admin mux**: bound to `127.0.0.1` (see operator-visible note above) — previously any peer that could reach the admin port could halt block production with an unauthenticated POST to `/pause`.
 
 ### Fix
 
@@ -13,21 +28,25 @@ v2.4.2 is a **recommended** patch release on top of v2.4.1. It ships a hotfix fo
 
 ### Feat
 
-- **Hot producer-key updates** (#4816) — Adds an authenticated admin endpoint for rotating delegate signing keys without restarting the node. `PUT /producer-keys` replaces the full list; `PATCH /producer-keys` performs incremental `add_keys` / `remove_addresses` updates. Authentication is via the `IOTEX_ADMIN_TOKEN` environment variable; the endpoint **fails closed** if the variable is unset, so the admin port can be safely exposed only on a trusted interface. Request bodies are capped and reject unknown JSON fields. Operator addresses are emitted on rotation via an explicit log line ("Updated producer keys in memory") and in the heartbeat log.
+- **Hot producer-key updates** (#4816) — Adds an authenticated admin endpoint for rotating delegate signing keys without restarting the node. `PUT /producer-keys` replaces the full list; `PATCH /producer-keys` performs incremental `add_keys` / `remove_addresses` updates. Authentication is via the `IOTEX_ADMIN_TOKEN` environment variable; the endpoint **fails closed** if the variable is unset. As of v2.4.2 the admin port is bound to `127.0.0.1` only — to manage keys remotely, tunnel via SSH or terminate auth in a local reverse proxy on the host. Request bodies are capped and reject unknown JSON fields. Operator addresses are emitted on rotation via an explicit log line ("Updated producer keys in memory") and in the heartbeat log.
 - **EIP-7702 `SetCode` tx support in `ioctl`** (#4837) — `ioctl action sign-auth` produces a signed EIP-7702 authorization (0x-hex RLP, compatible with `cast wallet sign-auth`-style tooling). `ioctl action transfer` and `ioctl contract invoke` gain an `--auth` flag that switches the action into a `SetCodeTx`. Non-legacy tx types are dispatched with TX_CONTAINER encoding (the chain's generic validator rejects IOTEX_PROTOBUF-encoded modern tx types). `--auth` is intentionally not registered on `contract deploy` since a `SetCodeTx` is always a CALL and the chain rejects a nil `to`.
 - **BundlePool hardening** (#4818) — Security hardening on top of the bundle pool (#4733): the broken sender-based `DeleteBundle` authorization is removed in favor of UUID as ownership token; a `maxLookahead` of 100 blocks prevents memory DoS from far-future target heights; a `maxSize` of 1000 caps total bundles; and bundle contents are restricted to `Transfer` / `Execution` / `txContainer` action types.
-- **Introduce `ioswarm` coordinator** — A new optional subsystem registered behind `ioswarm.enabled: false` by default in `config.yaml`. Existing nodes pick up the defaults transparently and require no action; see `ioswarm/README.md` in iotex-core for the design and operator notes for delegates who want to enable it.
+- **Introduce `ioswarm` coordinator** (#4817) — A new optional subsystem registered behind `ioswarm.enabled: false` by default in `config.yaml`. Existing nodes pick up the defaults transparently and require no action; see `ioswarm/README.md` in iotex-core for the design and operator notes for delegates who want to enable it.
+
+### Chore
+
+- **Upgrade `iotex-proto` to v0.6.6.**
 
 ## Upgrade Priority
 
-v2.4.2 is **recommended** for all node types. Api/gateway nodes that were unable to mint blocks because of the `workingSetStoreWithSecondary` error, and delegates that have hit the post-Upernavik mint panic, should upgrade as soon as possible.
+v2.4.2 is **mandatory** for all node types because of the peer-reachable DoS fixes in #4844. Api/gateway nodes that were unable to mint blocks because of the `workingSetStoreWithSecondary` error, and delegates that have hit the post-Upernavik mint panic, should upgrade as soon as possible.
 
-| Node type     | Action            |
-| ------------- | ----------------- |
-| Delegate      | **Recommended**   |
-| Fullnode      | **Recommended**   |
-| API node      | **Recommended**   |
-| Archive node  | **Recommended**   |
+| Node type     | Action          |
+| ------------- | --------------- |
+| Delegate      | **Mandatory**   |
+| Fullnode      | **Mandatory**   |
+| API node      | **Mandatory**   |
+| Archive node  | **Mandatory**   |
 
 No genesis or config schema changes; v2.4.2 is Go-only and introduces no new activation heights.
 

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
@@ -27,7 +27,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.1
+docker pull iotex/iotex-core:v2.4.2
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
@@ -26,7 +26,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.1 \
+        iotex/iotex-core:v2.4.2 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml


### PR DESCRIPTION
## Summary
- Bump all `v2.4.1` references to `v2.4.2` across READMEs (EN + CN, mainnet + testnet), `archive-node.md`, `CLAUDE.md`, and the `all_in_one_*.sh` scripts.
- Add `changelog/v2.4.2-release-note.md` covering the six commits between v2.4.1 and v2.4.2.
- No `config_*.yaml` / `genesis_*.yaml` changes — v2.4.2 is Go-only with no new activation heights.

## What's in v2.4.2

**Fix**
- Recover mint goroutine panics to keep the process alive (#4840)
- Disable premint on api nodes (#4839)

**Feat**
- Hot producer-key updates via authenticated admin endpoint (#4816)
- `ioctl` support for sending EIP-7702 SetCode tx (#4837)
- BundlePool hardened with size / lookahead limits (#4818)
- Introduce `ioswarm` coordinator (disabled by default) (#4817)

Per `release_flow.md`, **do not merge** until the final `v2.4.2` tag is pushed in iotex-core and Docker Hub finishes building the image (~20 min).

## Test plan
- [ ] Confirm `iotexproject/iotex-core` has the final `v2.4.2` tag and `iotex/iotex-core:v2.4.2` is available on Docker Hub before merging
- [ ] Verify `bash scripts/all_in_one_mainnet.sh` and `bash scripts/all_in_one_testnet.sh` pull the new image successfully on a clean host
- [ ] Spot-check that the `README*.md` and `archive-node.md` docker / curl / `git checkout` commands all reference `v2.4.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)