### PR TITLE
docs: add v2.4.3 transaction-log patch to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,5 +326,26 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.3
 ## <a name="gateway"/> Gateway Plugin
 Node with gateway plugin enabled will perform extra indexing to serve API requests of more detail chain information, such as number of actions in a block or query actions by hash.
 
+### Transaction-log patch (gateway / API / archive nodes)
+
+Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.3, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
+
+1. Download the patch file into the node's data directory:
+
+```
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+```
+
+2. Add the following line to the `chain:` section of `$IOTEX_HOME/etc/config.yaml`:
+
+```yaml
+chain:
+  patchTransactionLogPath: /var/data/txlog.db.patch
+```
+
+3. Restart the node.
+
+> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.3 release note](changelog/v2.4.3-release-note.md) for details.
+
 ## <a name="qa"/>Q&A
 Please refer [here](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) for Q&A.

--- a/README_CN.md
+++ b/README_CN.md
@@ -268,6 +268,27 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 为服务更多详细链信息的 API 请求，启用网关插件的节点将执行额外的索引。例如区块中的操作数量或通过哈希查询操作信息。
 
+### 交易日志补丁（网关 / API / 归档节点）
+
+**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.3 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
+
+1. 将补丁文件下载到节点的 data 目录：
+
+```
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+```
+
+2. 在 `$IOTEX_HOME/etc/config.yaml` 的 `chain:` 段中添加：
+
+```yaml
+chain:
+  patchTransactionLogPath: /var/data/txlog.db.patch
+```
+
+3. 重启节点。
+
+> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.3 release note](changelog/v2.4.3-release-note.md)。
+
 ## <a name="qa"/>常见问题
 
 请参考 [此处](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) 了解常见问题。

--- a/archive-node.md
+++ b/archive-node.md
@@ -56,6 +56,7 @@ mkdir -p $IOTEX_HOME/log
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/config_archive_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/master/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 curl https://storage.iotex.io/poll.mainnet.db > $IOTEX_HOME/data/poll.db
 ```
 ## <a name="download"/>Download Data
@@ -126,7 +127,8 @@ data<br>
 ├── index.db<br>
 ├── poll.db<br>
 ├── staking.index.db<br>
-└── trie.db.patch<br>
+├── trie.db.patch<br>
+└── txlog.db.patch<br>
 
 
 ## <a name="docker"/>Running Node using Docker

--- a/config_archive_mainnet.yaml
+++ b/config_archive_mainnet.yaml
@@ -14,6 +14,7 @@ chain:
   # producerPrivKey: SET YOUR PRIVATE KEY HERE (e.g., 96f0aa5e8523d6a28dc35c927274be4e931e74eaa720b418735debfcbfe712b8)
   chainDBPath: "/var/iotex-archive/data/chain.db"
   trieDBPatchFile: "/var/iotex-archive/data/trie.db.patch"
+  patchTransactionLogPath: "/var/iotex-archive/data/txlog.db.patch"
   trieDBPath: "/var/iotex-archive/data/trie.db"
   stakingPatchDir: "/var/iotex-archive/data"
   indexDBPath: "/var/iotex-archive/data/index.db"

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.2
+docker pull iotex/iotex-core:v2.4.3
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
@@ -27,7 +27,22 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.3 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
+
+# --- Optional: gateway / API node only (not needed for a delegate / fullnode) ---
+# If you run this node as a gateway (add `-plugin=gateway` to the docker run above) so it
+# serves API / transaction-log queries, also apply the transaction-log patch shipped with
+# v2.4.3 (see changelog/v2.4.3-release-note.md):
+#
+#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+#
+# then add the following to the chain: section of $IOTEX_HOME/etc/config.yaml and restart:
+#
+#   chain:
+#     patchTransactionLogPath: /var/data/txlog.db.patch
+#
+# IMPORTANT: only set patchTransactionLogPath if the file exists at that path — a node
+# configured with a missing patch file will fail to start.


### PR DESCRIPTION
Follow-up to #332 (the v2.4.3 release PR). Based on current `master` (the #332 merge).

Per `release_flow.md` → "Prepare release note and instruction" step 3 ("Update the version in README.md … **and add an instruction if necessary**") and `CLAUDE.md` → "Update for a new iotex-core release" (bump README + **scripts**), a v2.4.3 release change should carry the transaction-log patch **instruction** and bump the install **scripts**. #332 shipped the release note, the `txlog.db.patch` file, and the README/CLAUDE version bump, but did not add the install instruction or bump `scripts/all_in_one_mainnet.sh`. This PR completes those two items.

## Changes

| File | Change |
|---|---|
| `README.md` / `README_CN.md` | New "Transaction-log patch" subsection under **Gateway Plugin** — download + `patchTransactionLogPath` + restart, scoped to gateway/API/archive nodes. |
| `archive-node.md` | Download `txlog.db.patch` alongside `trie.db.patch`; add it to the expected `data/` tree. |
| `config_archive_mainnet.yaml` | Add `patchTransactionLogPath` (archive nodes always serve tx-log queries), matching the existing `trieDBPatchFile` convention. |
| `scripts/all_in_one_mainnet.sh` | Bump stale `v2.4.2` → `v2.4.3` (missed in #332); add an **optional** commented gateway block for the patch. |

Delegate / fullnodes are intentionally unchanged in their required flow — they don't serve tx-log queries, and a `patchTransactionLogPath` pointing at a missing file makes a node fail to start. The release-note fail-to-start caveat is repeated at every touch point.

## Open questions for @envestcc
1. **Was omitting the instruction from #332 intentional?** If the patch is meant to stay release-note-only (optional/API-only), say so and I'll drop the README/script parts and keep just the archive wiring.
2. **Opt-in vs universal.** Kept opt-in for gateway/API + baked-in for archive. Alternative: treat it like `trie.db.patch` (always download + config default) since loading it on a non-serving node is harmless — removes the fail-to-start footgun and the node-type branching.
3. **Upgrader.** `scripts/setup_fullnode.sh` is not touched. If gateway upgrades should auto-apply the patch, it needs a `_PLUGINS_=gateway`-gated download + `patchTransactionLogPath` injection (mirroring the existing `producerPrivKey` sed). Left out to avoid an untested change to the production upgrader.
3. **Archive upgrade path.** With `patchTransactionLogPath` now set in `config_archive_mainnet.yaml`, an existing archive node that refreshes config must also have `txlog.db.patch` present or it won't start (same as `trie.db.patch` today).

Kept as **draft** pending the scope decision above.