### PR TITLE
release v2.4.4: bump refs and add changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.3**. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.4**. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.4.2`)
+1. Update `version` references in README.md (search for `v2.4.4`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.2
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Here are the software versions we use:
 
-- MainNet: v2.4.3
+- MainNet: v2.4.4
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +33,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.3
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +48,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -94,7 +94,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.3 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -115,7 +115,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.3 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -139,7 +139,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.3
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -301,7 +301,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.4.3` | Target version (default: latest release) |
+| `--version=v2.4.4` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -315,7 +315,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.3
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
 ```
 
 **Notes:**
@@ -328,12 +328,12 @@ Node with gateway plugin enabled will perform extra indexing to serve API reques
 
 ### Transaction-log patch (gateway / API / archive nodes)
 
-Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.3, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
+Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.4, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
 
 1. Download the patch file into the node's data directory:
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 ```
 
 2. Add the following line to the `chain:` section of `$IOTEX_HOME/etc/config.yaml`:
@@ -345,7 +345,7 @@ chain:
 
 3. Restart the node.
 
-> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.3 release note](changelog/v2.4.3-release-note.md) for details.
+> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.4 release note](changelog/v2.4.4-release-note.md) for details.
 
 ## <a name="qa"/>Q&A
 Please refer [here](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) for Q&A.

--- a/README.md
+++ b/README.md
@@ -330,10 +330,11 @@ Node with gateway plugin enabled will perform extra indexing to serve API reques
 
 Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.4, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
 
-1. Download the patch file into the node's data directory:
+1. Download the patch file into the node's data directory and verify its checksum:
 
 ```
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
 2. Add the following line to the `chain:` section of `$IOTEX_HOME/etc/config.yaml`:

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.4.2
+- 主网：v2.4.4
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +32,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.2
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +47,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -92,7 +92,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -130,7 +130,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.2
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -270,12 +270,12 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 ### 交易日志补丁（网关 / API / 归档节点）
 
-**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.3 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
+**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.4 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
 
 1. 将补丁文件下载到节点的 data 目录：
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 ```
 
 2. 在 `$IOTEX_HOME/etc/config.yaml` 的 `chain:` 段中添加：
@@ -287,7 +287,7 @@ chain:
 
 3. 重启节点。
 
-> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.3 release note](changelog/v2.4.3-release-note.md)。
+> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.4 release note](changelog/v2.4.4-release-note.md)。
 
 ## <a name="qa"/>常见问题
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -272,10 +272,11 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 **对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.4 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
 
-1. 将补丁文件下载到节点的 data 目录：
+1. 将补丁文件下载到节点的 data 目录，并校验其 checksum：
 
 ```
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
 2. 在 `$IOTEX_HOME/etc/config.yaml` 的 `chain:` 段中添加：

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.4.2
+- 测试网：v2.4.4
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.2
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -89,7 +89,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -107,7 +107,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -127,7 +127,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.2
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.4.2
+- TestNet: v2.4.4
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.2
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -90,7 +90,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -110,7 +110,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -131,7 +131,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.2
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/archive-node.md
+++ b/archive-node.md
@@ -148,7 +148,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/iotex-archive/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -191,7 +191,7 @@ git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
 
 #checkout the code branch for archive node
-git checkout v2.4.2
+git checkout v2.4.4
 
 #build binary
 make build

--- a/changelog/v2.4.4-release-note.md
+++ b/changelog/v2.4.4-release-note.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-v2.4.4 is a **recommended** stability, correctness, and security patch release on top of v2.4.3. It continues the transaction-log integrity work started in v2.4.3: it corrects a SELFDESTRUCT transaction-log amount corruption that could mislead balance-reconstructing systems (indexers, wallets, exchanges). It also fixes non-archive nodes silently serving latest state for historical reads (which broke exchange balance reconciliation), hardens two panic paths so untrusted input can no longer crash a node, and closes a debug-tracing DoS vector on API nodes. No hardfork, no genesis change, and no config schema change is required for existing operators; v2.4.4 is Go-only and introduces no new activation heights.
+v2.4.4 is a **recommended** stability, correctness, and security patch release on top of v2.4.3. It continues the transaction-log integrity work started in v2.4.3: it corrects a SELFDESTRUCT transaction-log amount corruption that could mislead balance-reconstructing systems. It also fixes non-archive nodes silently serving latest state for historical reads (which broke exchange balance reconciliation), hardens two panic paths so untrusted input can no longer crash a node, and closes a debug-tracing DoS vector on API nodes. No hardfork, no genesis change, and no config schema change is required for existing operators; v2.4.4 is Go-only and introduces no new activation heights.
 
 > **Operator-/integrator-visible behavior change (#4917):** on a **non-archive** node, a historical state read at a block height below the tip (e.g. `eth_getBalance` / `eth_getCode` / storage reads at a past block) now returns an explicit `ErrNotSupported` ("use an archive node") error instead of silently returning latest-tip state. This is a correctness fix — the previous behavior returned wrong-but-plausible data — but any integration that was (knowingly or not) relying on historical queries against a non-archive endpoint will now get an error and should be pointed at an archive node. Archive nodes and `latest`-height queries are unaffected.
 
@@ -29,7 +29,7 @@ v2.4.4 is a **recommended** stability, correctness, and security patch release o
 
 v2.4.3 shipped `txlog.db.patch` for nodes that serve transaction-log queries (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`), correcting the historical forged in-contract-transfer records. The Go fixes in v2.4.4 stop *new* corrupted records from being written; already-recorded self-destruct amounts on mainnet are corrected the same way, via an updated `txlog.db.patch` regenerated with `txlogpatch -correct`.
 
-The v2.4.4 `txlog.db.patch` supersedes the v2.4.3 one and covers **239 blocks**: the **232** self-destruct amount corrections (`txlogpatch -correct`, heights `31217237`–`49346893`) plus the same **7** forged MakeTransfer records stripped in v2.4.3 (`49703669`–`49705590`, byte-identical to the v2.4.3 patch on those blocks). The self-destruct corruption ceased at height `49346893`; the range from there to the deploy height was exhaustively traced and contains no further affected records, so the patch is complete for all history.
+The v2.4.4 `txlog.db.patch` supersedes the v2.4.3 one and covers **239 blocks**: the **232** self-destruct amount corrections (`txlogpatch -correct`, heights `31217237`–`49346893`) plus the same **7** forged MakeTransfer records stripped in v2.4.3 (`49703669`–`49705590`, byte-identical to the v2.4.3 patch on those blocks).
 
 ```
 sha256  dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  txlog.db.patch
@@ -39,7 +39,7 @@ sha256  dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  txlog.
 
 ## Upgrade Priority
 
-v2.4.4 is **recommended** for all node types. API/gateway nodes that expose `debug_trace*`, and any operator serving balance or transaction-log data consumed by exchanges/indexers, should upgrade as soon as possible.
+v2.4.4 is **recommended** for all node types. API/gateway nodes that expose `debug_trace*`, and any operator serving transaction-log data should upgrade as soon as possible.
 
 | Node type     | Action            |
 | ------------- | ----------------- |

--- a/changelog/v2.4.4-release-note.md
+++ b/changelog/v2.4.4-release-note.md
@@ -29,7 +29,13 @@ v2.4.4 is a **recommended** stability, correctness, and security patch release o
 
 v2.4.3 shipped `txlog.db.patch` for nodes that serve transaction-log queries (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`), correcting the historical forged in-contract-transfer records. The Go fixes in v2.4.4 stop *new* corrupted records from being written; already-recorded self-destruct amounts on mainnet are corrected the same way, via an updated `txlog.db.patch` regenerated with `txlogpatch -correct`.
 
-> The patch is optional and consensus-neutral — it only affects the transaction logs served for the patched heights and does not change balances, receipts, or block hashes. To enable it, download the patch and set `chain.patchTransactionLogPath` (see README.md and the v2.4.3 release note). Only set `patchTransactionLogPath` if the file is present — a node configured with a missing patch file will fail to start.
+The v2.4.4 `txlog.db.patch` supersedes the v2.4.3 one and covers **239 blocks**: the **232** self-destruct amount corrections (`txlogpatch -correct`, heights `31217237`–`49346893`) plus the same **7** forged MakeTransfer records stripped in v2.4.3 (`49703669`–`49705590`, byte-identical to the v2.4.3 patch on those blocks). The self-destruct corruption ceased at height `49346893`; the range from there to the deploy height was exhaustively traced and contains no further affected records, so the patch is complete for all history.
+
+```
+sha256  dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  txlog.db.patch
+```
+
+> The patch is optional and consensus-neutral — it only affects the transaction logs served for the patched heights and does not change balances, receipts, or block hashes. To enable it, download the patch (verify the sha256 above) and set `chain.patchTransactionLogPath` (see README.md and the v2.4.3 release note). Only set `patchTransactionLogPath` if the file is present — a node configured with a missing patch file will fail to start.
 
 ## Upgrade Priority
 

--- a/changelog/v2.4.4-release-note.md
+++ b/changelog/v2.4.4-release-note.md
@@ -1,0 +1,49 @@
+# v2.4.4 Release Note
+
+## Summary
+
+v2.4.4 is a **recommended** stability, correctness, and security patch release on top of v2.4.3. It continues the transaction-log integrity work started in v2.4.3: it corrects a SELFDESTRUCT transaction-log amount corruption that could mislead balance-reconstructing systems (indexers, wallets, exchanges). It also fixes non-archive nodes silently serving latest state for historical reads (which broke exchange balance reconciliation), hardens two panic paths so untrusted input can no longer crash a node, and closes a debug-tracing DoS vector on API nodes. No hardfork, no genesis change, and no config schema change is required for existing operators; v2.4.4 is Go-only and introduces no new activation heights.
+
+> **Operator-/integrator-visible behavior change (#4917):** on a **non-archive** node, a historical state read at a block height below the tip (e.g. `eth_getBalance` / `eth_getCode` / storage reads at a past block) now returns an explicit `ErrNotSupported` ("use an archive node") error instead of silently returning latest-tip state. This is a correctness fix — the previous behavior returned wrong-but-plausible data — but any integration that was (knowingly or not) relying on historical queries against a non-archive endpoint will now get an error and should be pointed at an archive node. Archive nodes and `latest`-height queries are unaffected.
+
+## Changes
+
+### Security
+
+- **Enforce the `debug_trace*` execution timeout (was a no-op)** (#4886) — The trace execution timeout in `parseTracer` never fired: the deadline context was cancelled when `parseTracer` returned (before the EVM trace ran), so the watchdog saw `context.Canceled` instead of `context.DeadlineExceeded` and `tracer.Stop` was never called. A slow/expensive `debug_trace*` request could run unbounded — a DoS vector on API nodes that expose debug tracing. The watchdog is now armed for the full duration of trace execution, for every tracer type, and `traceBlock` surfaces a timeout as the RPC error instead of returning partial results. Fast traces are unaffected.
+- **Abort EVM execution when the trace timeout fires** (#4918) — Stopping the tracer alone only stopped result collection; the EVM kept executing until gas exhaustion, undercutting the timeout above. Now paired with EVM cancellation like upstream geth: a `TraceCanceller` travels in the trace context, each EVM registers its `Cancel` with it, and the watchdog aborts execution. A cancelled infinite-loop trace returns in ~100ms instead of burning the full gas budget. The consensus path never carries a canceller.
+
+### Fix
+
+- **Correct the SELFDESTRUCT transaction-log amount** (`[evm]`) — `generateSelfDestructTransferLog` stored the `stateDB.lastAddBalanceAmount` `*big.Int` directly into the `IN_CONTRACT_TRANSFER` transaction log for a SELFDESTRUCT. That pointer is mutated in place by the gas-deposit refund performed right after the EVM returns, so the recorded self-destruct log was retroactively overwritten with the gas-refund amount instead of the amount actually transferred to the beneficiary. Transaction logs are not part of any receipt or state root, so **balances, receipts, and block/state roots are unchanged** — but systems that reconstruct balances from transaction logs (indexers, wallets, exchanges) could be misled. The fix copies the amount instead of aliasing the mutable pointer, with an e2e regression test reproducing the on-chain MEV pattern (a value-carrying sub-call that reverts, then a self-destruct).
+- **Error on historical state read on a non-archive node instead of returning latest** (#4917) — A non-archive node keeps no historical state, so a read at a past height silently returned latest-tip state (e.g. `eth_getBalance` at an old block returned the current balance), which broke exchange reconciliation. `WorkingSetAtHeight` now returns `ErrNotSupported` for any explicit height below the tip on a non-archive node. Query path only; block production/validation are untouched. (See the operator note above.)
+- **Recover panics while validating a proposed block** (#4920) — A proposed block is untrusted input. A panic while processing a block's actions during `ValidateBlock` is now recovered and surfaced as an error (the block is rejected) instead of taking the validating node down. The working set is discarded by the caller on error, so no partial state leaks; the commit/`PutBlock` path stays fatal as before. Extends the same resilience added on the mint path in v2.4.2 (#4840).
+- **Evict the sender when an action panics during minting** (#4921) — If a single pending action panicked while being executed during minting, the panic unwound past the sender-eviction logic and was only caught by the mint goroutine's top-level recover, discarding the whole draft without removing the offending action from the pool — so the same action was retried on every subsequent mint attempt. The panic is now recovered around the single-action call and routed through normal error handling, which evicts the sender before the draft is abandoned. This turns a run of repeated draft failures into a one-time lost draft.
+- **Use a fresh tracer per transaction in `debug_traceBlock*`** (#4878) — `debug_traceBlockByNumber` / `debug_traceBlockByHash` shared one tracer across every transaction in the block, leaking per-tx state: `prestateTracer` accumulated touched accounts across txs, and `callTracer` never reset its callstack, dropping later txs with "incorrect number of top-level calls". A freshly instantiated tracer is now swapped in between transactions (matching geth), so per-tx traces are independent and ordered. Read-only tracing path; state/receipt roots are unaffected.
+
+### Tooling
+
+- **`txlogpatch`: add `-correct` mode for the self-destruct log fix** — The v2.4.3 transaction-log patch runs in *strip* mode (it removes forged `IN_CONTRACT_TRANSFER` records produced by the MakeTransfer issue). The self-destruct corruption instead *mis-records the amount* on a genuine record, so it must be rewritten, not removed. The new `-correct` mode reads a `correct_amount_rau` column from the CSV and rewrites only the amount (RAU) of the matched `IN_CONTRACT_TRANSFER` record, keeping its sender/recipient/type. The default strip mode is unchanged.
+
+## Transaction-log patch (mainnet)
+
+v2.4.3 shipped `txlog.db.patch` for nodes that serve transaction-log queries (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`), correcting the historical forged in-contract-transfer records. The Go fixes in v2.4.4 stop *new* corrupted records from being written; already-recorded self-destruct amounts on mainnet are corrected the same way, via an updated `txlog.db.patch` regenerated with `txlogpatch -correct`.
+
+> The patch is optional and consensus-neutral — it only affects the transaction logs served for the patched heights and does not change balances, receipts, or block hashes. To enable it, download the patch and set `chain.patchTransactionLogPath` (see README.md and the v2.4.3 release note). Only set `patchTransactionLogPath` if the file is present — a node configured with a missing patch file will fail to start.
+
+## Upgrade Priority
+
+v2.4.4 is **recommended** for all node types. API/gateway nodes that expose `debug_trace*`, and any operator serving balance or transaction-log data consumed by exchanges/indexers, should upgrade as soon as possible.
+
+| Node type     | Action            |
+| ------------- | ----------------- |
+| Delegate      | **Recommended**   |
+| Fullnode      | **Recommended**   |
+| API node      | **Recommended** (upgrade ASAP if `debug_trace*` is exposed) |
+| Archive node  | **Recommended**   |
+
+No genesis or config schema changes are required; v2.4.4 is Go-only and introduces no new activation heights.
+
+## Commits
+
+https://github.com/iotexproject/iotex-core/compare/v2.4.3...v2.4.4

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.3
+docker pull iotex/iotex-core:v2.4.4
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
@@ -27,7 +27,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.3 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -35,9 +35,9 @@ docker run -d --restart on-failure --name iotex \
 # --- Optional: gateway / API node only (not needed for a delegate / fullnode) ---
 # If you run this node as a gateway (add `-plugin=gateway` to the docker run above) so it
 # serves API / transaction-log queries, also apply the transaction-log patch shipped with
-# v2.4.3 (see changelog/v2.4.3-release-note.md):
+# v2.4.4 (see changelog/v2.4.4-release-note.md):
 #
-#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.3/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 #
 # then add the following to the chain: section of $IOTEX_HOME/etc/config.yaml and restart:
 #

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.2
+docker pull iotex/iotex-core:v2.4.4
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.2/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node)
 curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
@@ -26,7 +26,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.2 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml


### PR DESCRIPTION
## v2.4.4 release prep

Bumps image tag, config/genesis/patch URLs, and version references to **v2.4.4** across scripts and docs (mainnet EN/CN, testnet EN/CN, `archive-node.md`, `CLAUDE.md`), and adds `changelog/v2.4.4-release-note.md`.

v2.4.4 is a **Go-only** patch release on top of v2.4.3 — **no hardfork, no genesis change, no config schema change**. It covers the 8 iotex-core commits between `v2.4.3` and `v2.4.4-rc1`:

- **Transaction logs:** correct the SELFDESTRUCT `IN_CONTRACT_TRANSFER` amount corruption (`[evm]`); add `txlogpatch -correct` mode.
- **Factory robustness:** recover panics validating a proposed block (#4920); evict sender when an action panics during minting (#4921); error on historical state read on a non-archive node instead of returning latest — the exchange-reconciliation bug (#4917).
- **Debug-trace / API (incl. 2 DoS hardenings):** fresh tracer per tx in `debug_traceBlock*` (#4878); enforce the trace timeout that was a no-op (#4886); abort EVM execution when the trace timeout fires (#4918).

Commits: https://github.com/iotexproject/iotex-core/compare/v2.4.3...v2.4.4

### Notes for reviewers
- **Testnet/CN docs bumped v2.4.2 → v2.4.4.** They were left at v2.4.2 during the mainnet-only v2.4.3 patch; this restores parity (matching the v2.4.2-and-earlier pattern of bumping mainnet + testnet together). Flag if testnet should stay on a separate cadence.
- **`txlog.db.patch` regenerated (done).** The committed patch now covers 239 blocks: the 232 self-destruct amount corrections (`txlogpatch -correct`, heights 31217237–49346893) plus the same 7 forged MakeTransfer records stripped in v2.4.3 (49703669–49705590, byte-identical on those blocks). sha256 `dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986`. The corruption ceased at 49346893; the tail from there to the deploy height was exhaustively traced (2077 candidate txs, the validated 100%-recall superset) with zero further self-destruct records, so the patch is complete. Already deployed and verified on all 6 mainnet API/archive nodes (bm1×3 active + bm2×3 failover): forged block 49703669 serves 0 in-contract-transfers, self-destruct block 49145140 serves corrected {0.006, 0.6} (no gas-refund 0.274835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
