### PR TITLE
docs: use aria2c multi-threaded downloader for snapshots

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -67,22 +67,27 @@ See the [main README](README.md#agent-upgrade) for all available flags.
 - **`externalHost` must be IPv4.** The script now uses `curl -4 ip.sb` by default. If the detected IP is wrong, update `$IOTEX_HOME/etc/config.yaml` and restart.
 - **Snapshot download details:** The compressed snapshot is ~182GB and extracts to ~265GB (as of 2026-04) — these sizes grow over time, always verify by checking the URL as shown above.
   - **Option A (`--snapshot`)** downloads to `$IOTEX_HOME/tmp/` on the same partition. Needs enough disk for compressed + extracted data. No resume on failure.
-  - **Option B (manual, recommended):** Download the tarball yourself — supports resume and separate disk/volume:
+  - **Option B (manual, recommended):** Download the tarball yourself — supports resume and a separate disk/volume. **Prefer `aria2c` (multi-threaded): the snapshot is served from object storage where a single connection is rate-limited, so 16 parallel connections are typically several times faster.** Fall back to `curl` only if `aria2c` cannot be installed.
     ```bash
-    apt-get install -y pigz
+    apt-get install -y aria2 pigz
     mkdir -p $IOTEX_HOME/data
-    # Download with resume support (use a separate disk/volume if main disk is too small)
+    # Download with 16 parallel connections + resume (use a separate disk/volume if main disk is too small)
     DOWNLOAD_DIR=$IOTEX_HOME  # or /mnt/volume if main disk can't hold both
+    aria2c -x16 -s16 -c --file-allocation=none --max-tries=0 --retry-wait=10 \
+      -d $DOWNLOAD_DIR -o snapshot.tar.gz \
+      https://t.iotex.me/mainnet-data-snapshot-core-latest
+    # Extract with parallel decompression, then clean up
+    pigz -dc $DOWNLOAD_DIR/snapshot.tar.gz | tar -xf - -C $IOTEX_HOME/data/
+    rm -f $DOWNLOAD_DIR/snapshot.tar.gz
+    ```
+    Fallback if `aria2c` is unavailable (single-threaded, much slower on a file this large):
+    ```bash
     until curl -L -C - -o $DOWNLOAD_DIR/snapshot.tar.gz \
       --retry 20 --retry-delay 10 --speed-limit 100000 --speed-time 120 \
       https://t.iotex.me/mainnet-data-snapshot-core-latest; do
       echo "Download interrupted, resuming in 30s..."; sleep 30
     done
-    # Extract with parallel decompression, then clean up
-    pigz -dc $DOWNLOAD_DIR/snapshot.tar.gz | tar -xf - -C $IOTEX_HOME/data/
-    rm -f $DOWNLOAD_DIR/snapshot.tar.gz
     ```
-    For even faster downloads, use `aria2c -x16 -s16` instead of curl (16 parallel connections). aria2c also supports resume via `--continue=true`.
   - **Stream extraction (fallback — only when disk is very constrained):** Pipe curl directly into tar — no intermediate file, but cannot resume on failure. Only use when you truly cannot attach a temporary volume:
     ```bash
     apt-get install -y pigz

--- a/README.md
+++ b/README.md
@@ -55,11 +55,20 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/trie.
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
 
-4. Start from a **baseline snapshot** (rather than sync from the genesis block), run the following commands:
+4. Start from a **baseline snapshot** (rather than sync from the genesis block). The snapshot is a large file (~190GB) served from object storage, where a single connection is rate-limited and slow. Use the multi-threaded downloader `aria2c` — it opens several parallel connections (typically a few times faster) and can resume:
 
 ```
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
+# Install aria2 first — Ubuntu/Debian shown; use `yum install aria2` / `brew install aria2` on other systems
+sudo apt-get update && sudo apt-get install -y aria2
+
+# 16 parallel connections, resume-capable
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data.tar.gz \
+  https://t.iotex.me/mainnet-data-snapshot-core-latest
 ```
+
+> No `aria2c` available? You can fall back to single-threaded `curl`, but it will be much slower on a file this large:
+> `curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest`
 
 5. Extract the data package:
 
@@ -71,7 +80,9 @@ For advanced users, there are three options to consider:
 
 - Option 1: If you plan to run your node as a [gateway](#gateway), please use the snapshot with index data:
 ```
-curl -L -C - -o $IOTEX_HOME/data_index.tar.gz https://t.iotex.me/mainnet-data-snapshot-gateway-latest
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data_index.tar.gz \
+  https://t.iotex.me/mainnet-data-snapshot-gateway-latest
 tar -xzf data_index.tar.gz
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -54,10 +54,19 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/trie.
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
 
-4. 下载全量数据快照, 请运行以下命令:
+4. 下载全量数据快照。快照是存放在对象存储上的大文件(约 190GB),单连接会被限速、下载很慢。请使用多线程下载工具 `aria2c`——它会开启多条并行连接(通常快数倍),并支持断点续传:
 ```
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
+# 先安装 aria2 —— 以 Ubuntu/Debian 为例;其他系统用 `yum install aria2` / `brew install aria2`
+sudo apt-get update && sudo apt-get install -y aria2
+
+# 16 条并行连接,支持断点续传
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data.tar.gz \
+  https://t.iotex.me/mainnet-data-snapshot-core-latest
 ```
+
+> 没有 `aria2c`?可以退回到单线程 `curl`,但对这么大的文件会慢很多:
+> `curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest`
 
 5. 解压数据包
 
@@ -69,7 +78,9 @@ tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 
 - 选项1：如果计划将节点作为[网关](#gateway)运行，还需要额外下载带有索引数据的快照
 ```
-curl -L -C - -o $IOTEX_HOME/data_index.tar.gz https://t.iotex.me/mainnet-data-snapshot-gateway-latest
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data_index.tar.gz \
+  https://t.iotex.me/mainnet-data-snapshot-gateway-latest
 tar -xzf data_index.tar.gz
 ```
 

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -52,11 +52,20 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genes
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
 
-4. 下载全量数据快照, 请运行以下命令:
+4. 下载全量数据快照。快照是存放在对象存储上的大文件,单连接会被限速、下载很慢。请使用多线程下载工具 `aria2c`——它会开启多条并行连接(通常快数倍),并支持断点续传:
 
 ```
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
+# 先安装 aria2 —— 以 Ubuntu/Debian 为例;其他系统用 `yum install aria2` / `brew install aria2`
+sudo apt-get update && sudo apt-get install -y aria2
+
+# 16 条并行连接,支持断点续传
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data.tar.gz \
+  https://t.iotex.me/testnet-data-snapshot-core-latest
 ```
+
+> 没有 `aria2c`?可以退回到单线程 `curl`,但对这么大的文件会慢很多:
+> `curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest`
 
 5. 解压数据包
 
@@ -68,7 +77,9 @@ tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 
 - 选项1：如果计划将节点作为[网关](#gateway)运行，请额外下载带有索引数据的快照
 ```
-curl -L -C - -o $IOTEX_HOME/data_index.tar.gz https://t.iotex.me/testnet-data-snapshot-gateway-latest
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data_index.tar.gz \
+  https://t.iotex.me/testnet-data-snapshot-gateway-latest
 tar -xzf data_index.tar.gz
 ```
 

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -52,11 +52,20 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genes
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
 
-4. Start from a **baseline snapshot** (rather than sync from the genesis block), run the following commands:
+4. Start from a **baseline snapshot** (rather than sync from the genesis block). The snapshot is a large file served from object storage, where a single connection is rate-limited and slow. Use the multi-threaded downloader `aria2c` — it opens several parallel connections (typically a few times faster) and can resume:
 
 ```
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
+# Install aria2 first — Ubuntu/Debian shown; use `yum install aria2` / `brew install aria2` on other systems
+sudo apt-get update && sudo apt-get install -y aria2
+
+# 16 parallel connections, resume-capable
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data.tar.gz \
+  https://t.iotex.me/testnet-data-snapshot-core-latest
 ```
+
+> No `aria2c` available? You can fall back to single-threaded `curl`, but it will be much slower on a file this large:
+> `curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest`
 
 5. Extract the data package:
 
@@ -69,7 +78,9 @@ For advanced users, there are three options to consider:
 - Option 1: If you plan to run your node as a [gateway](#gateway), please use the snapshot with index data:
 
 ```
-curl -L -C - -o $IOTEX_HOME/data_index.tar.gz https://t.iotex.me/testnet-data-snapshot-gateway-latest
+aria2c -x16 -s16 -c --file-allocation=none \
+  -d $IOTEX_HOME -o data_index.tar.gz \
+  https://t.iotex.me/testnet-data-snapshot-gateway-latest
 tar -xzf data_index.tar.gz
 ```
 

--- a/archive-node.md
+++ b/archive-node.md
@@ -62,20 +62,23 @@ curl https://storage.iotex.io/poll.mainnet.db > $IOTEX_HOME/data/poll.db
 Next step is to download the snapshot data. You will
 need to download and uncompress this file.
 
-In the $IOTEX_HOME folder, run the following commands:
+In the $IOTEX_HOME folder, run the following commands. The snapshots are large files served from object storage, where a single connection is rate-limited and slow — use the multi-threaded downloader `aria2c` (several parallel connections, resume-capable):
 ```
-#download the data files and uncompress it
-curl -L -C - -O https://t.iotex.me/mainnet-data-snapshot-core-latest
-tar -xzf mainnet-data-e-20251228-042459-core.tar.gz
+# Install aria2 first — Ubuntu/Debian shown; use `yum install aria2` / `brew install aria2` on other systems
+sudo apt-get update && sudo apt-get install -y aria2
 
-curl -L -C - -O https://t.iotex.me/mainnet-data-snapshot-gateway-latest
-tar -xzf mainnet-data-e-20251228-042459-gateway.tar.gz
+# Download the three data files with 16 parallel connections each (resume-capable)
+aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o core.tar.gz         https://t.iotex.me/mainnet-data-snapshot-core-latest
+aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o gateway.tar.gz      https://t.iotex.me/mainnet-data-snapshot-gateway-latest
+aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o trie-history.tar.gz https://t.iotex.me/mainnet-data-snapshot-trie-history-latest
 
-curl -L -C - -O https://t.iotex.me/mainnet-data-snapshot-trie-history-latest
-tar -xzf mainnet-data-e-20251228-042459-trie-history.tar.gz
+# Uncompress
+tar -xzf core.tar.gz
+tar -xzf gateway.tar.gz
+tar -xzf trie-history.tar.gz
 ```
 >Note: the snapshot has a size of 450GB at this moment.
-Please take measures (for example use `nohup` at the front) to prevent possible interruption of the download process.
+`aria2c -c` resumes an interrupted download automatically — just re-run the same command. If you fall back to `curl`, wrap it with `nohup` to survive session drops.
 
 After successful download and uncompress operations, the $IOTEX_HOME/data folder
 will have these files:

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -16,8 +16,13 @@ curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/confi
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
-# Download core snapshot (for delegate node)
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
+# Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
+command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
+if command -v aria2c >/dev/null 2>&1; then
+    aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
+else
+    curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/mainnet-data-snapshot-core-latest
+fi
 tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 
 docker run -d --restart on-failure --name iotex \

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -15,8 +15,13 @@ mkdir -p $IOTEX_HOME/etc
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
 curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.3.8/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
-# Download core snapshot (for delegate node)
-curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
+# Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
+command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
+if command -v aria2c >/dev/null 2>&1; then
+    aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
+else
+    curl -L -C - -o $IOTEX_HOME/data.tar.gz https://t.iotex.me/testnet-data-snapshot-core-latest
+fi
 tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 
 docker run -d --restart on-failure --name iotex \

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -464,6 +464,31 @@ function disableGateway() {
     popd
 }
 
+function ensureAria2() {
+    command -v aria2c >/dev/null 2>&1 && return 0
+    echo -e "${YELLOW} aria2 not found, installing it for faster multi-threaded download...${NC}"
+    if [ "$(id -u)" = "0" ]; then
+        (apt-get update && apt-get install -y aria2) >/dev/null 2>&1
+    else
+        (sudo apt-get update && sudo apt-get install -y aria2) >/dev/null 2>&1
+    fi
+    command -v aria2c >/dev/null 2>&1
+}
+
+function downloadSnapshotFile() {
+    # $1 = URL, $2 = destination file. Snapshots are served from object storage that
+    # rate-limits single connections, so prefer multi-threaded aria2c (16 parallel
+    # connections + resume) and fall back to curl when aria2c is unavailable.
+    local url=$1 out=$2
+    if ensureAria2; then
+        aria2c -x16 -s16 -c --file-allocation=none --max-tries=0 --retry-wait=10 \
+            -d "$(dirname "$out")" -o "$(basename "$out")" "$url"
+    else
+        echo -e "${YELLOW} aria2 unavailable, falling back to single-threaded curl (slower)...${NC}"
+        curl -L -C - -o "$out" "$url"
+    fi
+}
+
 function donwloadBlockDataFile() {
     NODE_MAINNET_CORE_URL=https://t.iotex.me/mainnet-data-snapshot-core-latest
     NODE_TESTNET_CORE_URL=https://t.iotex.me/testnet-data-snapshot-core-latest
@@ -475,9 +500,9 @@ function donwloadBlockDataFile() {
 
     echo -e "${YELLOW} Downloading the core snapshot...${NC}"
     if [ "${_ENV_}X" = "mainnetX" ];then
-        curl -L -C - -o $SAVE_DIR/data-core.tar.gz $NODE_MAINNET_CORE_URL
+        downloadSnapshotFile $NODE_MAINNET_CORE_URL $SAVE_DIR/data-core.tar.gz
     else
-        curl -L -C - -o $SAVE_DIR/data-core.tar.gz $NODE_TESTNET_CORE_URL
+        downloadSnapshotFile $NODE_TESTNET_CORE_URL $SAVE_DIR/data-core.tar.gz
     fi
     echo -e "${YELLOW} Unzipping core snapshot...${NC}"
     tar xvf $SAVE_DIR/data-core.tar.gz -C $IOTEX_HOME
@@ -486,9 +511,9 @@ function donwloadBlockDataFile() {
     if [ "${_PLUGINS_}X" = "gatewayX" ];then
         echo -e "${YELLOW} Downloading the gateway snapshot...${NC}"
         if [ "${_ENV_}X" = "mainnetX" ];then
-            curl -L -C - -o $SAVE_DIR/data-gateway.tar.gz $NODE_MAINNET_GATEWAY_URL
+            downloadSnapshotFile $NODE_MAINNET_GATEWAY_URL $SAVE_DIR/data-gateway.tar.gz
         else
-            curl -L -C - -o $SAVE_DIR/data-gateway.tar.gz $NODE_TESTNET_GATEWAY_URL
+            downloadSnapshotFile $NODE_TESTNET_GATEWAY_URL $SAVE_DIR/data-gateway.tar.gz
         fi
         echo -e "${YELLOW} Unzipping gateway snapshot...${NC}"
         tar xvf $SAVE_DIR/data-gateway.tar.gz -C $IOTEX_HOME


### PR DESCRIPTION
## What
Switch snapshot downloads across the repo from single-threaded `curl` to the multi-threaded `aria2c` downloader (16 parallel connections + resume) — in both the human docs and the setup script. Each doc tells operators to install `aria2` first (apt / yum / brew) and keeps a `curl` fallback; the scripts auto-install `aria2` and fall back to `curl` when it is unavailable.

## Why
Snapshot tarballs are served from object storage (Cloudflare R2 via `storage.iotex.io`), where **single-connection throughput is rate-limited and highly variable** — measured 0.5–22 MB/s, jumping around regardless of file offset. This is a known R2 characteristic: it does not accelerate single-stream sequential reads of large objects, and these files are intentionally **not edge-cached** (a ~190GB object exceeds the CDN plan's max cacheable size, one-shot edge hit-rate is ~0, and R2→CDN egress is already free — so caching wouldn't help).

The reliable, zero-cost fix is **client-side parallelism**. A quick 4-connection test aggregated to ~24 MB/s vs ~7 MB/s single-stream; `aria2c -x16` typically saturates the node's uplink.

## Changes
- **README.md / README_CN.md / README_testnet.md / README_CN_testnet.md** — core + gateway snapshot downloads use `aria2c`, with an install note and a `curl` fallback.
- **archive-node.md** — core / gateway / trie-history downloads use `aria2c`.
- **scripts/all_in_one_{mainnet,testnet}.sh** — prefer `aria2c` when available, auto-install it, fall back to `curl` (safe on non-apt systems).
- **scripts/setup_fullnode.sh** — the `--snapshot` / `--auto` path (`donwloadBlockDataFile()`) now downloads via a new `downloadSnapshotFile()` helper: prefer aria2c (auto-install as root or via sudo), fall back to curl.
- **AGENT.md** — promote `aria2c` from a secondary tip to the recommended primary method.

Canonical command: `aria2c -x16 -s16 -c --file-allocation=none` (16 parallel connections, resume-capable, no upfront 190GB preallocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)