### PR TITLE
fix: extract snapshot tarballs into $IOTEX_HOME/data

### DIFF
--- a/.github/workflows/snapshot-checks.yml
+++ b/.github/workflows/snapshot-checks.yml
@@ -1,0 +1,37 @@
+name: snapshot-checks
+
+# Guards the snapshot install path, which has no other automated coverage.
+#
+# The bug these exist for was a disagreement between two facts that are each
+# fine on their own: the published tarballs are flat, and the extractions in
+# this repo name a destination. Only when the two drift apart does a fresh
+# install silently sync from genesis after downloading ~190GB. So each fact is
+# asserted separately — neither check downloads a snapshot or starts a node.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    # Off the hour on purpose: the tarball layout can change without any commit
+    # to this repo, so this needs to run on a clock, not only on PRs.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  extract-targets:
+    name: extraction targets are $IOTEX_HOME/data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/ci/check_extract_targets.sh
+
+  snapshot-layout:
+    name: published snapshots are flat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Fetches the first megabyte of each of the four tarballs (~4MB total).
+      # Retries internally; re-run the job if the storage host is having a
+      # bad day.
+      - run: ./scripts/ci/check_snapshot_layout.sh

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For advanced users, there are three options to consider:
 aria2c -x16 -s16 -c --file-allocation=none \
   -d $IOTEX_HOME -o data_index.tar.gz \
   https://t.iotex.me/mainnet-data-snapshot-gateway-latest
-tar -xzf data_index.tar.gz
+tar -xzf $IOTEX_HOME/data_index.tar.gz -C $IOTEX_HOME/data/
 ```
 
 If you need to run your node in archive mode to provide full historical data, please go to [Archive Node](./archive-node.md).

--- a/README_CN.md
+++ b/README_CN.md
@@ -81,7 +81,7 @@ tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 aria2c -x16 -s16 -c --file-allocation=none \
   -d $IOTEX_HOME -o data_index.tar.gz \
   https://t.iotex.me/mainnet-data-snapshot-gateway-latest
-tar -xzf data_index.tar.gz
+tar -xzf $IOTEX_HOME/data_index.tar.gz -C $IOTEX_HOME/data/
 ```
 
 如果需要以 archive 模式运行提供全量历史数据，请转到 [Archive Node](./archive-node.md)

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -80,7 +80,7 @@ tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data/
 aria2c -x16 -s16 -c --file-allocation=none \
   -d $IOTEX_HOME -o data_index.tar.gz \
   https://t.iotex.me/testnet-data-snapshot-gateway-latest
-tar -xzf data_index.tar.gz
+tar -xzf $IOTEX_HOME/data_index.tar.gz -C $IOTEX_HOME/data/
 ```
 
 - 选择2：如果计划从 0 区块高度开始同步链上数据而不使用来自以太坊旧的节点代表数据，执行以下命令设置旧的节点代表数据：

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -81,7 +81,7 @@ For advanced users, there are three options to consider:
 aria2c -x16 -s16 -c --file-allocation=none \
   -d $IOTEX_HOME -o data_index.tar.gz \
   https://t.iotex.me/testnet-data-snapshot-gateway-latest
-tar -xzf data_index.tar.gz
+tar -xzf $IOTEX_HOME/data_index.tar.gz -C $IOTEX_HOME/data/
 ```
 
 - Optional 2: If you only want to sync chain data from 0 height without relaying on legacy delegate election data from Ethereum, you can setup legacy delegate election data with following command:

--- a/archive-node.md
+++ b/archive-node.md
@@ -73,10 +73,12 @@ aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o core.tar.gz        
 aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o gateway.tar.gz      https://t.iotex.me/mainnet-data-snapshot-gateway-latest
 aria2c -x16 -s16 -c --file-allocation=none -d $IOTEX_HOME -o trie-history.tar.gz https://t.iotex.me/mainnet-data-snapshot-trie-history-latest
 
-# Uncompress
-tar -xzf core.tar.gz
-tar -xzf gateway.tar.gz
-tar -xzf trie-history.tar.gz
+# Uncompress into $IOTEX_HOME/data — the tarballs are flat (no leading data/
+# directory), so the extraction target must be given explicitly
+mkdir -p $IOTEX_HOME/data
+tar -xzf $IOTEX_HOME/core.tar.gz         -C $IOTEX_HOME/data
+tar -xzf $IOTEX_HOME/gateway.tar.gz      -C $IOTEX_HOME/data
+tar -xzf $IOTEX_HOME/trie-history.tar.gz -C $IOTEX_HOME/data
 ```
 >Note: the snapshot has a size of 450GB at this moment.
 `aria2c -c` resumes an interrupted download automatically — just re-run the same command. If you fall back to `curl`, wrap it with `nohup` to survive session drops.

--- a/changelog/v1.2-instruction.md
+++ b/changelog/v1.2-instruction.md
@@ -1,4 +1,11 @@
 
+> **Historical document — for the v1.2.0 upgrade only.**
+> The combined `t.iotex.me/{mainnet,testnet}-data-with-idx-latest` snapshots referenced
+> below have been retired and now return HTTP 404. Snapshots are published as separate
+> core and gateway tarballs; the URLs in this page have been updated to the current
+> gateway snapshot. For a current install or upgrade, follow [README.md](../README.md)
+> instead of this page.
+
 ## Instruction for Mainnet v1.2.0 Upgrade
 First, go to the `iotex-var` folder on your node (where it has 3 sub-folders `etc`, `data`, `log`)
 ```
@@ -38,9 +45,9 @@ You should see log output from the node.
 #### Option 2 - if you are running the node WITH API gateway enabled
 In this case, you'll need to wipe out the data and start from latest snapshot, due to index file in v1.2 is not backward-compatible.
 ```
-rm -rf $IOTEX_HOME/data
-curl -L https://t.iotex.me/mainnet-data-with-idx-latest > $IOTEX_HOME/data.tar.gz
-tar -xzf data.tar.gz
+rm -rf $IOTEX_HOME/data && mkdir -p $IOTEX_HOME/data
+curl -L https://t.iotex.me/mainnet-data-snapshot-gateway-latest > $IOTEX_HOME/data.tar.gz
+tar -xzf $IOTEX_HOME/data.tar.gz -C $IOTEX_HOME/data
 ```
 then start the node using image v1.2.0
 ```
@@ -74,7 +81,7 @@ You should see log output from the node.
 ## Instruction for Testnet v1.2.0 Upgrade
 To upgrade to testnet v1.2.0, the procedure is same as that of mainnet, except these 2:
 
-1. Download the snapshot from `https://t.iotex.me/testnet-data-with-idx-latest` if needed
+1. Download the snapshot from `https://t.iotex.me/testnet-data-snapshot-gateway-latest` if needed
 2. Update the config and genesis files like below
 
   * Save the private key and external IP address, i.e., the `producerPrivKey:` and `externalHost` line in file `$IOTEX_HOME/etc/config.yaml`

--- a/scripts/ci/check_extract_targets.sh
+++ b/scripts/ci/check_extract_targets.sh
@@ -50,6 +50,10 @@ checked=0
 # Only shell and markdown are in scope; those are the files node operators copy
 # commands out of. Comment lines in shell scripts are skipped so that
 # commented-out history does not have to be kept compliant.
+#
+# scripts/ci/ is excluded: it is tooling, not something anyone runs against a
+# node, and this file quotes the correct tar form in its own failure message —
+# without the exclusion the check reports itself.
 while IFS= read -r file; do
     lineno=0
     while IFS= read -r line; do
@@ -73,7 +77,7 @@ while IFS= read -r file; do
             failed=1
         fi
     done < "$file"
-done < <(git ls-files '*.sh' '*.md')
+done < <(git ls-files '*.sh' '*.md' | grep -v '^scripts/ci/')
 
 if [ $failed -ne 0 ]; then
     echo

--- a/scripts/ci/check_extract_targets.sh
+++ b/scripts/ci/check_extract_targets.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Assert that every snapshot extraction in this repo targets $IOTEX_HOME/data.
+#
+# The container mounts $IOTEX_HOME/data as /var/data and setup_fullnode.sh keys
+# its install/upgrade detection off $IOTEX_HOME/data/chain.db, so a snapshot
+# unpacked into $IOTEX_HOME itself leaves the mounted data directory empty and
+# the node syncs from genesis. That is what happened when the snapshot URLs were
+# split into core/gateway tarballs: all_in_one_*.sh was updated, the two setup
+# scripts and the docs were not, and nothing caught it.
+#
+# This is a static check — no network, no downloads. It scans shell scripts and
+# markdown for tar invocations in extract mode and requires each one to name an
+# explicit destination under $IOTEX_HOME/data. Extractions unrelated to chain
+# data are listed in ALLOWED below.
+#
+# Usage: scripts/ci/check_extract_targets.sh
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# tar invoked in extract mode: `tar xvf`, `tar -xzf`, `tar -xf -`, ...
+# Deliberately does not match `tar -tzf` (list) or `tar -czf` (create).
+EXTRACT_RE='(^|[|;&(]|[[:space:]])tar[[:space:]]+-?[a-zA-Z-]*x'
+
+# A destination under $IOTEX_HOME/data, with or without a trailing slash.
+DEST_RE='(-C|--directory)[[:space:]]+\$(IOTEX_HOME|\{IOTEX_HOME\})/data/?([[:space:]]|$)'
+
+# Extractions that have nothing to do with chain data.
+ALLOWED=(
+    'go1\.[0-9.]+\.linux-amd64\.tar\.gz'   # Go toolchain, archive-node.md
+    'prometheus-[0-9]'                     # monitoring stack
+    'cmake-[0-9]'                          # build tooling
+    '\$\{1\}-\$\{2\}\.tar\.gz'             # get_systemstat.sh diagnostics bundle
+)
+
+isAllowed() {
+    local line=$1 pattern
+    for pattern in "${ALLOWED[@]}"; do
+        if echo "$line" | grep -Eq "$pattern"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+failed=0
+checked=0
+
+# Only shell and markdown are in scope; those are the files node operators copy
+# commands out of. Comment lines in shell scripts are skipped so that
+# commented-out history does not have to be kept compliant.
+while IFS= read -r file; do
+    lineno=0
+    while IFS= read -r line; do
+        lineno=$((lineno + 1))
+
+        case "$file" in
+            *.sh)
+                echo "$line" | grep -Eq '^[[:space:]]*#' && continue
+                ;;
+        esac
+
+        echo "$line" | grep -Eq "$EXTRACT_RE" || continue
+        isAllowed "$line" && continue
+
+        checked=$((checked + 1))
+        if echo "$line" | grep -Eq "$DEST_RE"; then
+            echo "ok   $file:$lineno"
+        else
+            echo "FAIL $file:$lineno"
+            echo "     $(echo "$line" | sed 's/^[[:space:]]*//')"
+            failed=1
+        fi
+    done < "$file"
+done < <(git ls-files '*.sh' '*.md')
+
+if [ $failed -ne 0 ]; then
+    echo
+    echo "Snapshot extractions must name their destination explicitly:"
+    echo "    tar -xzf <tarball> -C \$IOTEX_HOME/data"
+    echo
+    echo "The tarballs are flat (chain-*.db at the archive root), \$IOTEX_HOME/data"
+    echo "is what the container mounts as /var/data, and setup_fullnode.sh looks for"
+    echo "\$IOTEX_HOME/data/chain.db to tell an upgrade from a fresh install."
+    echo
+    echo "If the extraction above is not chain data, add it to ALLOWED in $0."
+    exit 1
+fi
+
+echo
+echo "All $checked snapshot extractions target \$IOTEX_HOME/data."

--- a/scripts/ci/check_snapshot_layout.sh
+++ b/scripts/ci/check_snapshot_layout.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Assert that the published snapshot tarballs are flat, i.e. their members sit
+# at the archive root (chain-*.db, bloomfilter.index.db, ...) with no leading
+# data/ directory.
+#
+# Everything in this repo that unpacks a snapshot does so with
+# `-C $IOTEX_HOME/data`, which is only correct while that holds. If the
+# publishing side ever goes back to wrapping the contents in a data/ directory,
+# those extractions would silently produce $IOTEX_HOME/data/data/... and a node
+# that syncs from genesis. Nothing in this repo would otherwise notice.
+#
+# Only the first megabyte of each tarball is fetched: a tar member header is the
+# first 512 bytes, so that is enough to read the first member name. gzip and tar
+# both complain about the truncated stream after that, which is expected and
+# ignored.
+#
+# Usage: scripts/ci/check_snapshot_layout.sh
+#        SNAPSHOT_URLS="url1 url2" scripts/ci/check_snapshot_layout.sh
+set -uo pipefail
+
+if [ -n "${SNAPSHOT_URLS:-}" ]; then
+    # shellcheck disable=SC2206
+    URLS=($SNAPSHOT_URLS)
+else
+    URLS=(
+        "https://t.iotex.me/mainnet-data-snapshot-core-latest"
+        "https://t.iotex.me/mainnet-data-snapshot-gateway-latest"
+        "https://t.iotex.me/testnet-data-snapshot-core-latest"
+        "https://t.iotex.me/testnet-data-snapshot-gateway-latest"
+    )
+fi
+
+RANGE_BYTES=1048575
+ATTEMPTS=3
+failed=0
+
+# Lists the members of a remote tarball that are readable from its first
+# megabyte, with the archive's own root entry ("." / "./") dropped — that entry
+# is present or absent depending on how the archive was created and says nothing
+# about the layout, but taking it as "the first member" would mask a payload
+# nested under data/.
+#
+# -L is required: t.iotex.me redirects to the object storage host, and without
+# it curl returns an empty redirect body that decompresses to nothing.
+leadingMembers() {
+    local url=$1 out=$2
+    curl -sSL --max-time 120 -r "0-${RANGE_BYTES}" "$url" -o "$out" || return 1
+    [ -s "$out" ] || return 1
+    gzip -dc "$out" 2>/dev/null | tar -tf - 2>/dev/null \
+        | sed 's|^\./||' \
+        | grep -v '^\.\?/\?$'
+}
+
+for url in "${URLS[@]}"; do
+    tmp=$(mktemp)
+    members=""
+    for attempt in $(seq 1 $ATTEMPTS); do
+        members=$(leadingMembers "$url" "$tmp")
+        [ -n "$members" ] && break
+        if [ "$attempt" -lt "$ATTEMPTS" ]; then
+            echo "  retrying $url ($attempt/$ATTEMPTS)..." >&2
+            sleep 5
+        fi
+    done
+    size=$(wc -c < "$tmp" | tr -d ' ')
+    rm -f "$tmp"
+
+    if [ -z "$members" ]; then
+        # Treated as a failure rather than a skip: an empty read is exactly what
+        # a broken redirect or an HTML error page looks like, and silently
+        # passing on it would defeat the purpose of the check.
+        echo "FAIL $url"
+        echo "     could not read any member name (downloaded ${size} bytes)"
+        failed=1
+        continue
+    fi
+
+    nested=$(echo "$members" | grep '^data/' | head -1)
+    if [ -n "$nested" ]; then
+        echo "FAIL $url"
+        echo "     member '$nested' sits under data/ — the tarball is no longer flat."
+        echo "     Snapshot extractions in this repo pass '-C \$IOTEX_HOME/data'"
+        echo "     and would now nest the payload one level too deep."
+        failed=1
+    else
+        echo "ok   $url -> $(echo "$members" | head -1)"
+    fi
+done
+
+if [ $failed -ne 0 ]; then
+    echo
+    echo "Snapshot layout changed. Update the extraction targets in scripts/ and"
+    echo "the docs together, then adjust this check."
+    exit 1
+fi
+
+echo
+echo "All snapshot tarballs are flat."

--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -503,6 +503,10 @@ function donwloadBlockDataFile() {
 
     SAVE_DIR=$IOTEX_HOME/tmp
     mkdir -p $SAVE_DIR
+    # The snapshot tarballs are flat (chain-*.db / bloomfilter.index.db at the
+    # root, no data/ prefix), so they must be extracted into $IOTEX_HOME/data,
+    # which is what gets mounted as /var/data in the container.
+    mkdir -p $IOTEX_HOME/data
 
     echo -e "${YELLOW} Downloading the core snapshot...${NC}"
     if [ "${_ENV_}X" = "mainnetX" ];then
@@ -511,7 +515,7 @@ function donwloadBlockDataFile() {
         downloadSnapshotFile $NODE_TESTNET_CORE_URL $SAVE_DIR/data-core.tar.gz
     fi
     echo -e "${YELLOW} Unzipping core snapshot...${NC}"
-    tar xvf $SAVE_DIR/data-core.tar.gz -C $IOTEX_HOME
+    tar xvf $SAVE_DIR/data-core.tar.gz -C $IOTEX_HOME/data
     echo -e "${YELLOW} Core snapshot done.${NC}"
 
     if [ "${_PLUGINS_}X" = "gatewayX" ];then
@@ -522,7 +526,7 @@ function donwloadBlockDataFile() {
             downloadSnapshotFile $NODE_TESTNET_GATEWAY_URL $SAVE_DIR/data-gateway.tar.gz
         fi
         echo -e "${YELLOW} Unzipping gateway snapshot...${NC}"
-        tar xvf $SAVE_DIR/data-gateway.tar.gz -C $IOTEX_HOME
+        tar xvf $SAVE_DIR/data-gateway.tar.gz -C $IOTEX_HOME/data
         echo -e "${YELLOW} Gateway snapshot done.${NC}"
     fi
 

--- a/scripts/setup_fullnode_marketplace.sh
+++ b/scripts/setup_fullnode_marketplace.sh
@@ -115,17 +115,21 @@ function donwloadBlockDataFile() {
 
     SAVE_DIR=$IOTEX_HOME/tmp
     mkdir -p $SAVE_DIR
+    # The snapshot tarballs are flat (chain-*.db / bloomfilter.index.db at the
+    # root, no data/ prefix), so they must be extracted into $IOTEX_HOME/data,
+    # which is what gets mounted as /var/data in the container.
+    mkdir -p $IOTEX_HOME/data
 
     echo -e "${YELLOW} Downloading the core snapshot...${NC}"
     curl -sSL -C - -o $SAVE_DIR/data-core.tar.gz $NODE_MAINNET_CORE_URL
     echo -e "${YELLOW} Unzipping core snapshot...${NC}"
-    tar xvf $SAVE_DIR/data-core.tar.gz -C $IOTEX_HOME
+    tar xvf $SAVE_DIR/data-core.tar.gz -C $IOTEX_HOME/data
     echo -e "${YELLOW} Core snapshot done.${NC}"
 
     echo -e "${YELLOW} Downloading the gateway snapshot...${NC}"
     curl -sSL -C - -o $SAVE_DIR/data-gateway.tar.gz $NODE_MAINNET_GATEWAY_URL
     echo -e "${YELLOW} Unzipping gateway snapshot...${NC}"
-    tar xvf $SAVE_DIR/data-gateway.tar.gz -C $IOTEX_HOME
+    tar xvf $SAVE_DIR/data-gateway.tar.gz -C $IOTEX_HOME/data
     echo -e "${YELLOW} Gateway snapshot done.${NC}"
 
     echo -e "${YELLOW} Done.${NC}"


### PR DESCRIPTION
## Problem

The snapshot tarballs are **flat** — the root members are `chain-*.db` / `bloomfilter.index.db`, with no leading `data/` directory. Verified by streaming the first member of all four published tarballs:

| tarball | first member |
|---|---|
| `mainnet-data-snapshot-core-latest` | `chain-00000001.db` |
| `mainnet-data-snapshot-gateway-latest` | `bloomfilter.index.db` |
| `testnet-data-snapshot-core-latest` | `chain-00000001.db` |
| `testnet-data-snapshot-gateway-latest` | `bloomfilter.index.db` |

Several call sites still extracted them with `-C $IOTEX_HOME`, a leftover from the pre-split single-package era. eec89cb fixed `all_in_one_*.sh` when it moved to the split URLs, but the two setup scripts and the docs never followed.

The container mounts `$IOTEX_HOME/data` as `/var/data`, and the install/upgrade detection in `setup_fullnode.sh` keys off `$IOTEX_HOME/data/chain.db`. Extracting one level too high means `bash setup_fullnode.sh --auto --snapshot` dumps ~190GB into `$IOTEX_HOME` while the mounted `data/` stays empty — the node then syncs from genesis.

Note the failure order: `checkPrivateKey` runs *before* `donwloadBlockDataFile`, so the `data/chain.db` check is not what breaks first. The empty mount is. The check-failure is the second-order symptom on the **next** run: the script still sees no `data/chain.db`, treats the node as a fresh install again, and re-downloads the whole snapshot — and since `_IS_UPGRADE_` also requires `data/chain.db`, it can never reach the upgrade path.

Fixing the extraction target restores detection: `chain.db` *is* present in the snapshot alongside the `chain-%08d.db` aux files (`filedao` treats it as the master file), so `[ -f data/chain.db ]` holds after a correct extraction.

## Changes

- **`scripts/setup_fullnode.sh`**, **`scripts/setup_fullnode_marketplace.sh`** — extract into `$IOTEX_HOME/data`, and `mkdir -p` it first: `tar -C` fails on a missing directory, and today only the fresh-install branch creates it.
- **`README.md`**, **`README_CN.md`**, **`README_testnet.md`**, **`README_CN_testnet.md`** — Option 1 (gateway snapshot) had no `-C` at all, so it extracted into the current directory; it also read a relative `data_index.tar.gz` while `aria2c` writes to `$IOTEX_HOME`. Step 5 in each was already correct.
- **`archive-node.md`** — same missing `-C` for all three archive tarballs, directly above a listing that claims the files land in `$IOTEX_HOME/data`.
- **`changelog/v1.2-instruction.md`** — `t.iotex.me/{mainnet,testnet}-data-with-idx-latest` now returns HTTP 404 (302 → `storage.iotex.io/...tar.gz` → 404). Repointed at the gateway snapshot, fixed the same extraction bug on that page, and added a banner marking it historical.

`AGENT.md` and `all_in_one_*.sh` were already correct and are unchanged.

## Verification

- Confirmed all four tarballs are flat (table above).
- `bash -n` clean on both modified scripts.
- Exercised the fixed extraction against a synthetic flat tarball shaped like production (`chain.db`, `chain-00000001.db`, `trie.db`, `index.db`): files land in `data/`, and `[ -f $IOTEX_HOME/data/chain.db ]` passes.
- Grepped the tree — every remaining snapshot extraction now targets `$IOTEX_HOME/data`.

## CI

This PR adds the repo's first `.github/workflows/`. The bug needed two facts to disagree, each fine alone, so each is asserted separately — neither check downloads a snapshot or starts a node:

- `scripts/ci/check_extract_targets.sh` — static scan of shell and markdown for tar invocations in extract mode, requiring each to target `$IOTEX_HOME/data`. No network. Run against the pre-fix tree it flags 12 sites and passes the 12 that were already correct; on this branch all 24 pass.
- `scripts/ci/check_snapshot_layout.sh` — reads the leading members of each of the four published tarballs from a 1MB range request and fails if any sit under `data/`. ~4MB total, runs on PRs and daily. Catches the inverse regression, where the publishing side starts wrapping contents in `data/` and the now-correct extractions silently become wrong.

Both jobs are green on this branch.

## End-to-end verification

Ran the fixed `setup_fullnode.sh --auto --snapshot` against the testnet snapshot (75.7GB — same code path as mainnet, an eighth the data) on a scratch directory of an internal host. Results:

- Nothing landed at `$IOTEX_HOME` root — only `data/ etc/ log/ monitor/ tmp/`. Before the fix the 53 chain files land here and the mounted `data/` stays empty.
- `$IOTEX_HOME/data/chain.db` present, 53 files, 94GB.
- Node started at **height 46,079,958 and synced forward** (`State factory started height=46079958`, then `block sync intervals Start=46079959`, committing blocks). With the bug this reads height 1.
- No panics or fatals; container healthy on the testnet p2p port.

All test artifacts were removed afterwards.

One prerequisite issue surfaced during the run and is **not fixed here**: `checkDockerCompose()` requires the EOL `docker-compose` v1 binary, which is absent on hosts with a current Docker (Compose is a plugin, `docker compose`). Three internal hosts all failed this check and needed a shim. That blocks `setup_fullnode.sh` entirely on any modern install and deserves its own issue.
