### PR TITLE
fix: support Compose v2, which is all modern Docker installs have

### DIFF
--- a/scripts/setup_fullnode.sh
+++ b/scripts/setup_fullnode.sh
@@ -46,11 +46,22 @@ function checkDockerPermissions() {
     fi
 }
 
+# Set by checkDockerCompose() to whichever Compose is available. Used unquoted
+# at call sites so that "docker compose" word-splits into command + subcommand.
+COMPOSE_CMD=""
+
 function checkDockerCompose() {
-    docker-compose --version > /dev/null 2>&1
-    if [ $? -eq 127 ];then
-        echo -e "$RED docker-compose command not found $NC"
-        echo -e "Please install it first"
+    # Compose v2 ships as a Docker CLI plugin invoked as `docker compose`. The
+    # standalone `docker-compose` v1 binary is end-of-life and is absent from
+    # current Docker installs, so requiring it fails outright on a recent host.
+    # Prefer the plugin, fall back to the legacy binary.
+    if docker compose version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker compose"
+    elif docker-compose --version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo -e "$RED Neither 'docker compose' nor 'docker-compose' is available $NC"
+        echo -e "Install the Compose plugin, e.g. 'apt-get install docker-compose-plugin'"
         exit 1
     fi
 }
@@ -238,7 +249,7 @@ function procssNotUpdate() {
         else
             enableMonitor
             pushd $IOTEX_MONITOR_HOME
-            docker-compose up -d --no-deps monitor
+            $COMPOSE_CMD up -d --no-deps monitor
             if [ $? -eq 0 ];then
                 echo -e "${YELLOW} You can access 'localhost:3000' to view node monitoring ${NC}"
                 echo -e "${YELLOW} Default User/Pass: admin/admin. ${NC}"
@@ -532,7 +543,7 @@ function donwloadBlockDataFile() {
 function startupWithMonitor() {
     echo -e "Start iotex-server and monitor."
     pushd $IOTEX_MONITOR_HOME
-    docker-compose up -d --no-recreate
+    $COMPOSE_CMD up -d --no-recreate
     if [ $? -eq 0 ];then
         echo -e "${YELLOW} If you first create monitor, you can access 'localhost:3000' to view node monitoring ${NC}"
         echo -e "${YELLOW} Default User/Pass: admin/admin. ${NC}" 
@@ -543,7 +554,7 @@ function startupWithMonitor() {
 function startup() {
     echo -e "Start iotex-server."
     pushd $IOTEX_MONITOR_HOME
-    docker-compose up -d iotex
+    $COMPOSE_CMD up -d iotex
     docker ps | grep iotex-monitor|grep -v grep > /dev/null 2>&1
     if [ $? -eq 0 ];then
         docker stop iotex-monitor
@@ -559,14 +570,14 @@ function startupNode() {
         #check node running
         sleep 5
         pushd $IOTEX_MONITOR_HOME
-        docker-compose ps
+        $COMPOSE_CMD ps
         popd
     else
         startup
         #check node running
         sleep 5
         pushd $IOTEX_MONITOR_HOME
-        docker-compose ps iotex
+        $COMPOSE_CMD ps iotex
         popd
     fi
 
@@ -602,7 +613,7 @@ function startAutoUpdate() {
 function main() {
     # Check and clean
     checkDockerPermissions     # Determine the current user can run docker
-    checkDockerCompose         # Determin the docker-compose is installed
+    checkDockerCompose         # Determine which Compose implementation is available
     setVar $@                  # Set global variable
     determinIotexHome          # Determine the $IOTEX_HOME
     checkPrivateKey            # Determine the producerPrivKey in the config file is exist.

--- a/scripts/setup_fullnode_marketplace.sh
+++ b/scripts/setup_fullnode_marketplace.sh
@@ -35,11 +35,22 @@ function checkDockerPermissions() {
     fi
 }
 
+# Set by checkDockerCompose() to whichever Compose is available. Used unquoted
+# at call sites so that "docker compose" word-splits into command + subcommand.
+COMPOSE_CMD=""
+
 function checkDockerCompose() {
-    docker-compose --version > /dev/null 2>&1
-    if [ $? -eq 127 ];then
-        echo -e "$RED docker-compose command not found $NC"
-        echo -e "Please install it first"
+    # Compose v2 ships as a Docker CLI plugin invoked as `docker compose`. The
+    # standalone `docker-compose` v1 binary is end-of-life and is absent from
+    # current Docker installs, so requiring it fails outright on a recent host.
+    # Prefer the plugin, fall back to the legacy binary.
+    if docker compose version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker compose"
+    elif docker-compose --version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo -e "$RED Neither 'docker compose' nor 'docker-compose' is available $NC"
+        echo -e "Install the Compose plugin, e.g. 'apt-get install docker-compose-plugin'"
         exit 1
     fi
 }
@@ -134,7 +145,7 @@ function donwloadBlockDataFile() {
 function startup() {
     echo -e "Start iotex-server."
     pushd $IOTEX_MONITOR_HOME
-    docker-compose up -d iotex
+    $COMPOSE_CMD up -d iotex
     popd
 }
 
@@ -143,14 +154,14 @@ function startupNode() {
     #check node running
     sleep 5
     pushd $IOTEX_MONITOR_HOME
-    docker-compose ps iotex
+    $COMPOSE_CMD ps iotex
     popd
 }
 
 function main() {
     # Check and clean
     checkDockerPermissions     # Determine the current user can run docker
-    checkDockerCompose         # Determin the docker-compose is installed
+    checkDockerCompose         # Determine which Compose implementation is available
     setVar                     # Set global variable
 
     determinIotexHome          # Determine the $IOTEX_HOME

--- a/scripts/setup_monitor_alert.sh
+++ b/scripts/setup_monitor_alert.sh
@@ -25,11 +25,22 @@ function checkDockerPermissions() {
     fi
 }
 
+# Set by checkDockerCompose() to whichever Compose is available. Used unquoted
+# at call sites so that "docker compose" word-splits into command + subcommand.
+COMPOSE_CMD=""
+
 function checkDockerCompose() {
-    docker-compose --version > /dev/null 2>&1
-    if [ $? -eq 127 ];then
-        echo -e "$RED docker-compose command not found $NC"
-        echo -e "Please install it first"
+    # Compose v2 ships as a Docker CLI plugin invoked as `docker compose`. The
+    # standalone `docker-compose` v1 binary is end-of-life and is absent from
+    # current Docker installs, so requiring it fails outright on a recent host.
+    # Prefer the plugin, fall back to the legacy binary.
+    if docker compose version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker compose"
+    elif docker-compose --version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo -e "$RED Neither 'docker compose' nor 'docker-compose' is available $NC"
+        echo -e "Install the Compose plugin, e.g. 'apt-get install docker-compose-plugin'"
         exit 1
     fi
 }

--- a/scripts/stop_fullnode.sh
+++ b/scripts/stop_fullnode.sh
@@ -25,11 +25,22 @@ function checkDockerPermissions() {
     fi
 }
 
+# Set by checkDockerCompose() to whichever Compose is available. Used unquoted
+# at call sites so that "docker compose" word-splits into command + subcommand.
+COMPOSE_CMD=""
+
 function checkDockerCompose() {
-    docker-compose --version > /dev/null 2>&1
-    if [ $? -eq 127 ];then
-        echo -e "$RED docker-compose command not found $NC"
-        echo -e "Please install it first"
+    # Compose v2 ships as a Docker CLI plugin invoked as `docker compose`. The
+    # standalone `docker-compose` v1 binary is end-of-life and is absent from
+    # current Docker installs, so requiring it fails outright on a recent host.
+    # Prefer the plugin, fall back to the legacy binary.
+    if docker compose version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker compose"
+    elif docker-compose --version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo -e "$RED Neither 'docker compose' nor 'docker-compose' is available $NC"
+        echo -e "Install the Compose plugin, e.g. 'apt-get install docker-compose-plugin'"
         exit 1
     fi
 }
@@ -58,7 +69,7 @@ function confirmEnvironmentVariable() {
 function stopNode() {
     echo -e "${YELLOW}Stopping iotex-server.${NC}"
     pushd $IOTEX_HOME/monitor
-    docker-compose stop
+    $COMPOSE_CMD stop
 
     # stop auto-updatem, if it is running.
     ps -ef | grep "$IOTEX_HOME/bin/auto-update" > /dev/null

--- a/scripts/update_silence.sh
+++ b/scripts/update_silence.sh
@@ -50,11 +50,22 @@ function checkDockerPermissions() {
     fi
 }
 
+# Set by checkDockerCompose() to whichever Compose is available. Used unquoted
+# at call sites so that "docker compose" word-splits into command + subcommand.
+COMPOSE_CMD=""
+
 function checkDockerCompose() {
-    docker-compose --version > /dev/null 2>&1
-    if [ $? -eq 127 ];then
-        echo -e "$RED docker-compose command not found $NC"
-        echo -e "Please install it first"
+    # Compose v2 ships as a Docker CLI plugin invoked as `docker compose`. The
+    # standalone `docker-compose` v1 binary is end-of-life and is absent from
+    # current Docker installs, so requiring it fails outright on a recent host.
+    # Prefer the plugin, fall back to the legacy binary.
+    if docker compose version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker compose"
+    elif docker-compose --version > /dev/null 2>&1;then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo -e "$RED Neither 'docker compose' nor 'docker-compose' is available $NC"
+        echo -e "Install the Compose plugin, e.g. 'apt-get install docker-compose-plugin'"
         exit 1
     fi
 }
@@ -69,7 +80,7 @@ function setVar() {
 
 function isNotRunning() {
     pushd $IOTEX_MONITOR_HOME
-    docker-compose ps iotex
+    $COMPOSE_CMD ps iotex
     if [ $? -eq 0 ];then
         return 0
     fi
@@ -183,7 +194,7 @@ function addAdminPortToCompose() {
 function startup() {
     echo -e "Start iotex-server."
     pushd $IOTEX_MONITOR_HOME
-    docker-compose up -d iotex
+    $COMPOSE_CMD up -d iotex
     popd
 }
 
@@ -192,7 +203,7 @@ function startupNode() {
         #check node running
         sleep 5
         pushd $IOTEX_MONITOR_HOME
-        docker-compose ps iotex
+        $COMPOSE_CMD ps iotex
         popd
 }
 


### PR DESCRIPTION
## Problem

`checkDockerCompose()` requires the standalone `docker-compose` v1 binary:

```bash
docker-compose --version > /dev/null 2>&1
if [ $? -eq 127 ];then
    echo -e "$RED docker-compose command not found $NC"
    exit 1
fi
```

That binary is end-of-life. Current Docker packages ship Compose as a CLI plugin invoked as `docker compose` and do not install `docker-compose` at all. On any such host these scripts exit 1 before doing any work.

For `setup_fullnode.sh` this is the first thing `main()` does after the docker permission check, so it never reaches config download, image pull, or the snapshot code. A fresh gateway or delegate install is impossible without hand-installing a deprecated binary or dropping in a shim.

Verified on a host running Docker 29.5.3 with Compose v5.1.4 as a plugin and no `docker-compose` binary:

```
$ bash setup_fullnode.sh testnet --auto --home=/…
 docker-compose command not found
Please install it first
exit=1
```

Three of our own internal hosts are in this state.

## Changes

Each script now detects what is available, preferring the plugin and falling back to the legacy binary:

```bash
if docker compose version > /dev/null 2>&1;then
    COMPOSE_CMD="docker compose"
elif docker-compose --version > /dev/null 2>&1;then
    COMPOSE_CMD="docker-compose"
else
    …exit 1 with an actionable message…
fi
```

Call sites invoke `$COMPOSE_CMD`, intentionally unquoted so `docker compose` splits into command plus subcommand.

All five scripts carried the same copied check:

| Script | Invocations rewritten |
|---|---|
| `setup_fullnode.sh` | 5 (`up -d --no-deps monitor`, `up -d --no-recreate`, `up -d iotex`, `ps`, `ps iotex`) |
| `update_silence.sh` | 3 |
| `setup_fullnode_marketplace.sh` | 2 |
| `stop_fullnode.sh` | 1 (`stop`) |
| `setup_monitor_alert.sh` | 0 — see below |

In `setup_monitor_alert.sh` the check is vestigial: that script never invokes Compose, so the gate could only ever produce a false failure. It is fixed rather than removed to keep the five scripts consistent, but removing it outright would also be reasonable.

## Verification

On the same host, with the fixed scripts:

- `checkDockerCompose()` passes and the script proceeds through config download and image pull.
- `$COMPOSE_CMD up -d iotex` — `Network monitor_default Created`, `Container iotex Created`, `Container iotex Started`.
- `$COMPOSE_CMD ps iotex` — reports the container.
- `stop_fullnode.sh`'s `$COMPOSE_CMD stop` — `Container iotex Stopping` / `Stopped`, container reaches `Exited`.
- `bash -n` clean on all five.

The test node was started without `--snapshot`, so it then crash-looped syncing from genesis on an unrelated pre-existing problem — see below. That happens well after Compose has done its job; the container was created, started, queried and stopped through the plugin.

## Unrelated issue found while testing (not fixed here)

A fresh install that syncs from genesis dies with:

```
fatal  Failed to start server.
error: failed to get tip height: 401 Unauthorized: account disabled
```

The Infura key baked into the shipped `config_testnet.yaml` (`gravityChainAPIs`) is disabled, and the committee needs the gravity chain to fetch legacy delegate election data. README "Optional 3" already tells operators to substitute their own key when syncing from height 0, so this is documented rather than new — but the dead default produces a restart loop with a stack trace instead of a clear message. Snapshot-based installs are unaffected: `poll.db` ships in the snapshot and the committee logs `stop syncing` without ever calling out to Ethereum.

Worth its own issue.

## Relation to #337

Independent, no overlap in the touched hunks. They are complementary for the case that prompted #337 — an operator building a gateway node from a snapshot:

- Following the README commands by hand: #337 alone is sufficient.
- Running `setup_fullnode.sh --auto --snapshot plugin=gateway` on a host with a current Docker: both are needed, since without this PR the script exits before reaching the code #337 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
