### PR TITLE
release: v2.5.0 - Zanzibar on MainNet at 53155801

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0-rc0 on TestNet** and **v2.4.4 on MainNet** — v2.5.0-rc0 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0-rc1 on TestNet** and **v2.4.4 on MainNet** — v2.5.0-rc1 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.5.0-rc0`)
+1. Update `version` references in README.md (search for `v2.5.0-rc1`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0-rc0
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0-rc1
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0**. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0 on TestNet** and **v2.4.4 on MainNet** — v2.5.0 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0-rc1 on TestNet** and **v2.4.4 on MainNet** — v2.5.0-rc1 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0-rc1 on TestNet** and **v2.5.0 on MainNet** — Zanzibar is now scheduled on both: TestNet activated it at 46880641 with Beta at 47141281, and MainNet takes Zanzibar, Beta and Gamma together at 52813081. MainNet carries its fork heights in the binary rather than in `genesis_mainnet.yaml`, so a MainNet upgrade is a binary roll with no genesis change. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0 on TestNet** and **v2.4.4 on MainNet** — v2.5.0 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0-rc0 on TestNet** and **v2.4.4 on MainNet** — v2.5.0-rc0 carries the Zanzibar hardfork, which is scheduled on TestNet only, so the MainNet docs deliberately still point at v2.4.4. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.5.0`)
+1. Update `version` references in README.md (search for `v2.5.0-rc0`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0-rc0
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **IoTeX Delegate Manual** repository - configuration and operational
 
 ## Version Alignment
 
-This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.4.4**. When iotex-core releases a new version:
+This repository is versioned in sync with [iotex-core](https://github.com/iotexproject/iotex-core). The current release is **v2.5.0**. When iotex-core releases a new version:
 1. Update version references in README.md, config files, and scripts
 2. Add a release note in `changelog/`
 3. Create a PR but do NOT merge until the final release is tagged in iotex-core
@@ -38,7 +38,7 @@ See `release_flow.md` for the complete release process.
 ## Common Tasks
 
 ### Update for a new iotex-core release
-1. Update `version` references in README.md (search for `v2.4.4`)
+1. Update `version` references in README.md (search for `v2.5.0`)
 2. Update docker image tags in `scripts/all_in_one_mainnet.sh` and `scripts/all_in_one_testnet.sh`
 3. Add release note in `changelog/vX.Y.Z-release-note.md`
 4. Update `config_mainnet.yaml` and `config_testnet.yaml` if needed
@@ -56,7 +56,7 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 ### Non-interactive upgrade (AI agent / CI)
 ```bash
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var --force  # reinstall same version
 ```
 Flags: `--auto` (skip prompts), `--home=` (IOTEX_HOME), `--version=` (target version), `--force` (bypass same-version check), `--monitor` (enable monitoring), `plugin=gateway` (enable gateway).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,34 @@
 - [Agent Guide](AGENT.md)
 - [Q&A](#qa)
 
+> ### ⚠️ Zanzibar hardfork — MainNet block 52813081 (2026-09-28 ~10:30 CST)
+>
+> Upgrade to `v2.5.0` before that block. A node left on `v2.4.4` will fork off
+> the network.
+>
+> **`genesis_mainnet.yaml` does not change.** MainNet carries its fork heights
+> in the binary, not in the genesis file, so there is nothing to re-download —
+> unlike the TestNet rollout, where the genesis had to be replaced. Pull the
+> image, restart, done. `config_mainnet.yaml` is unchanged as well.
+>
+> Zanzibar activates IIP-59 on-chain voter reward distribution. Beta and Gamma
+> ride the same block: MainNet has activated none of them, so it takes all
+> three corrections from the first block IIP-59 is live rather than scheduling
+> a window that knowingly runs behaviour already found to be wrong.
+>
+> **Delegates distributing through Hermes:** at that block the protocol
+> auto-migrates every candidate whose reward address is a Hermes vault, but
+> only if its DelegateProfile carries both reward-portion fields. A candidate
+> missing either one is left on the Hermes path — nothing breaks, but it does
+> not get on-chain distribution, and the migration runs in that one block and
+> never again. Check yours before the fork. See the
+> [v2.5.0 release note](changelog/v2.5.0-release-note.md).
+
 ## <a name="status"/>Release Status
 
 Here are the software versions we use:
 
-- MainNet: v2.4.4
+- MainNet: v2.5.0
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +56,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +71,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -105,7 +128,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -126,7 +149,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -150,7 +173,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -312,7 +335,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.4.4` | Target version (default: latest release) |
+| `--version=v2.5.0` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -326,7 +349,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0
 ```
 
 **Notes:**
@@ -339,12 +362,12 @@ Node with gateway plugin enabled will perform extra indexing to serve API reques
 
 ### Transaction-log patch (gateway / API / archive nodes)
 
-Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.4, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
+Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.5.0, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
 
 1. Download the patch file into the node's data directory and verify its checksum:
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -357,7 +380,7 @@ chain:
 
 3. Restart the node.
 
-> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.4 release note](changelog/v2.4.4-release-note.md) for details.
+> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.5.0 release note](changelog/v2.5.0-release-note.md) for details.
 
 ## <a name="qa"/>Q&A
 Please refer [here](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) for Q&A.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Here are the software versions we use:
 
-- MainNet: v2.5.0
+- MainNet: v2.4.4
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +33,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +48,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -105,7 +105,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -126,7 +126,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -150,7 +150,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -312,7 +312,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.5.0` | Target version (default: latest release) |
+| `--version=v2.4.4` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -326,7 +326,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
 ```
 
 **Notes:**
@@ -339,12 +339,12 @@ Node with gateway plugin enabled will perform extra indexing to serve API reques
 
 ### Transaction-log patch (gateway / API / archive nodes)
 
-Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.5.0, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
+Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.4, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
 
 1. Download the patch file into the node's data directory and verify its checksum:
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -357,7 +357,7 @@ chain:
 
 3. Restart the node.
 
-> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.5.0 release note](changelog/v2.5.0-release-note.md) for details.
+> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.4 release note](changelog/v2.4.4-release-note.md) for details.
 
 ## <a name="qa"/>Q&A
 Please refer [here](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) for Q&A.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Here are the software versions we use:
 
-- MainNet: v2.4.4
+- MainNet: v2.5.0
 
 ## <a name="testnet"/>Join TestNet
 To start and run a testnet node, please click [**Join Testnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_testnet.md)
@@ -33,7 +33,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. Set the environment with the following commands:
@@ -48,9 +48,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -105,7 +105,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -126,7 +126,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -150,7 +150,7 @@ Same as [Join MainNet](#mainnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -312,7 +312,7 @@ The upgrade script supports a non-interactive mode for use with AI agents, CI/CD
 |---|---|
 | `--auto` | Non-interactive mode, skip all prompts |
 | `--home=/path` | Set `$IOTEX_HOME` directory |
-| `--version=v2.4.4` | Target version (default: latest release) |
+| `--version=v2.5.0` | Target version (default: latest release) |
 | `--force` | Reinstall even if already running the same version |
 | `--snapshot` | Download blockchain snapshot (recommended for fresh install) |
 | `--monitor` | Enable monitoring |
@@ -326,7 +326,7 @@ bash setup_fullnode.sh --auto --home=/path/to/iotex-var --snapshot
 bash setup_fullnode.sh --auto --home=/path/to/iotex-var
 
 # Upgrade to a specific version
-bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.4.4
+bash setup_fullnode.sh --auto --home=/path/to/iotex-var --version=v2.5.0
 ```
 
 **Notes:**
@@ -339,12 +339,12 @@ Node with gateway plugin enabled will perform extra indexing to serve API reques
 
 ### Transaction-log patch (gateway / API / archive nodes)
 
-Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.4.4, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
+Nodes that **serve transaction-log queries** (`GetTransactionLogByActionHash`, `GetTransactionLogByBlockHeight`) should apply the transaction-log patch shipped with v2.5.0, which corrects a set of historical in-contract-transfer records. Delegate / fullnodes that do not serve these queries do not need it.
 
 1. Download the patch file into the node's data directory and verify its checksum:
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -357,7 +357,7 @@ chain:
 
 3. Restart the node.
 
-> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.4.4 release note](changelog/v2.4.4-release-note.md) for details.
+> **Important:** only set `patchTransactionLogPath` if the patch file exists at that path — a node configured with a missing patch file will **fail to start**. The patch is read-only and does not change balances, receipts, or block hashes. See the [v2.5.0 release note](changelog/v2.5.0-release-note.md) for details.
 
 ## <a name="qa"/>Q&A
 Please refer [here](https://github.com/iotexproject/iotex-bootstrap/wiki/Q&A) for Q&A.

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.4.4
+- 主网：v2.5.0
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +32,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +47,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -103,7 +103,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -121,7 +121,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -141,7 +141,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -281,12 +281,12 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 ### 交易日志补丁（网关 / API / 归档节点）
 
-**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.4 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
+**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.5.0 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
 
 1. 将补丁文件下载到节点的 data 目录，并校验其 checksum：
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -299,7 +299,7 @@ chain:
 
 3. 重启节点。
 
-> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.4 release note](changelog/v2.4.4-release-note.md)。
+> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.5.0 release note](changelog/v2.5.0-release-note.md)。
 
 ## <a name="qa"/>常见问题
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.5.0
+- 主网：v2.4.4
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +32,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.4.4
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +47,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -103,7 +103,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -121,7 +121,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -141,7 +141,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0
+git checkout v2.4.4
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -281,12 +281,12 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 ### 交易日志补丁（网关 / API / 归档节点）
 
-**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.5.0 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
+**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.4 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
 
 1. 将补丁文件下载到节点的 data 目录，并校验其 checksum：
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -299,7 +299,7 @@ chain:
 
 3. 重启节点。
 
-> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.5.0 release note](changelog/v2.5.0-release-note.md)。
+> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.4 release note](changelog/v2.4.4-release-note.md)。
 
 ## <a name="qa"/>常见问题
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,11 +14,29 @@
 - [网关插件](#gateway)
 - [常见问题](#qa)
 
+> ### ⚠️ Zanzibar 硬分叉 — 主网 52813081 块（2026-09-28 约 10:30 CST）
+>
+> 必须在该高度之前升级到 `v2.5.0`。停留在 `v2.4.4` 的节点会从网络分叉出去。
+>
+> **`genesis_mainnet.yaml` 不变。** 主网的分叉高度写在二进制里、不在 genesis 文件中，
+> 所以没有需要重新下载的东西——这与测试网那次不同（测试网必须替换 genesis）。
+> 拉镜像、重启，就完成了。`config_mainnet.yaml` 同样不变。
+>
+> Zanzibar 启用 IIP-59 链上投票人奖励发放。Beta 和 Gamma 与它同一个高度：主网三者
+> 都未激活过，所以从 IIP-59 生效的第一个块起就带上全部修正，而不是安排一段明知
+> 行为有误的窗口。
+>
+> **通过 Hermes 分发的 delegate 请注意：** 该高度上协议会自动迁移所有 reward
+> address 指向 Hermes vault 的候选人，但**前提是其 DelegateProfile 已配置两个
+> 分成字段**。缺任一字段的候选人会被留在 Hermes 老路径——不会出错，但拿不到链上
+> 分发，而且这个迁移只在那一个块执行、之后不再重来。请在分叉前检查。
+> 详见 [v2.5.0 release note](changelog/v2.5.0-release-note.md)。
+
 ## <a name="status"/>发布状态
 
 以下是当前我们使用的软件版本：
 
-- 主网：v2.4.4
+- 主网：v2.5.0
 
 ## <a name="testnet"/>加入测试网
 如果你要启动节点加入测试网，请点击[**加入测试网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN_testnet.md)
@@ -32,7 +50,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. 使用以下命令设置运行环境
@@ -47,9 +65,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -103,7 +121,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -121,7 +139,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -141,7 +159,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io
@@ -281,12 +299,12 @@ bash <(curl -s https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/ma
 
 ### 交易日志补丁（网关 / API / 归档节点）
 
-**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.4.4 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
+**对外提供交易日志查询**（`GetTransactionLogByActionHash`、`GetTransactionLogByBlockHeight`）的节点应安装 v2.5.0 引入的交易日志补丁，它会修正一组历史合约内转账记录。不对外提供这些查询的 delegate / 全节点无需安装。
 
 1. 将补丁文件下载到节点的 data 目录，并校验其 checksum：
 
 ```
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 echo "dee9406afc991d5439ab4c27bc85fa658e1fb241ddabe1cc5fef18f27d728986  $IOTEX_HOME/data/txlog.db.patch" | sha256sum -c
 ```
 
@@ -299,7 +317,7 @@ chain:
 
 3. 重启节点。
 
-> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.4.4 release note](changelog/v2.4.4-release-note.md)。
+> **重要：** 仅当补丁文件确实存在于该路径时才设置 `patchTransactionLogPath` —— 若配置了该路径但文件缺失，节点将**无法启动**。该补丁为只读，不会改变余额、收据或区块哈希。详见 [v2.5.0 release note](changelog/v2.5.0-release-note.md)。
 
 ## <a name="qa"/>常见问题
 

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -2,6 +2,19 @@
 
 *最新版本请参考 https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md*
 
+
+> ### ⚠️ Zanzibar 硬分叉 — 测试网 46880641 块（2026-08-21 约 10:00 CST）
+>
+> 必须在该高度之前升级到 `v2.5.0-rc0` **并**重新下载 `genesis_testnet.yaml`。
+> 停留在旧二进制或旧 genesis 的节点会从网络分叉出去。
+>
+> 激活高度较早前的草案有过调整，请重新下载 genesis，不要假设手上那份是最新的。
+> `config_testnet.yaml` 本次没有变化，可以沿用。
+>
+> 希望启用 IIP-59 链上投票人奖励发放的 delegate，需要用
+> `ioctl stake2 voterrewardoptin` 开启，并在 DelegateProfile 合约中设置分成比例。
+> 详见 [v2.5.0 release note](changelog/v2.5.0-release-note.md)。
+
 ## 索引
 
 - [发布状态](#status)

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.4.4
+- 测试网：v2.5.0
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -100,7 +100,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -118,7 +118,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -138,7 +138,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -3,13 +3,20 @@
 *最新版本请参考 https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md*
 
 
-> ### ⚠️ Zanzibar 硬分叉 — 测试网 46880641 块（2026-08-21 约 10:00 CST）
+> ### ⚠️ Zanzibar Beta 硬分叉 — 测试网 47141281 块（2026-08-29 约 06:00 CST）
 >
-> 必须在该高度之前升级到 `v2.5.0-rc0` **并**重新下载 `genesis_testnet.yaml`。
+> 必须在该高度之前升级到 `v2.5.0-rc1` **并**重新下载 `genesis_testnet.yaml`。
 > 停留在旧二进制或旧 genesis 的节点会从网络分叉出去。
 >
-> 激活高度较早前的草案有过调整，请重新下载 genesis，不要假设手上那份是最新的。
-> `config_testnet.yaml` 本次没有变化，可以沿用。
+> **先升级二进制，再换 genesis。** `v2.5.0-rc0` 的节点根本读不了新的
+> `genesis_testnet.yaml`——它无法识别新增的两个字段（`zanzibarBetaHeight` 和
+> `account.testnetGrants`），会直接启动失败。
+> 请先拉取 `v2.5.0-rc1` 并重启，然后再替换 genesis。`config_testnet.yaml`
+> 本次没有变化，可以沿用。
+>
+> Zanzibar 已于 2026-08-21 在 46880641 块激活，目前已经生效。Zanzibar Beta
+> 包含对 Zanzibar 所启用功能的三处修正，因此需要单独的激活高度——如果放在
+> Zanzibar 的高度上生效，会改写这条链已经出块确认过的历史。
 >
 > 希望启用 IIP-59 链上投票人奖励发放的 delegate，需要用
 > `ioctl stake2 voterrewardoptin` 开启，并在 DelegateProfile 合约中设置分成比例。
@@ -30,7 +37,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.5.0-rc0
+- 测试网：v2.5.0-rc1
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -44,7 +51,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.5.0-rc0
+docker pull iotex/iotex-core:v2.5.0-rc1
 ```
 
 2. 使用以下命令设置运行环境
@@ -59,8 +66,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -113,7 +120,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0-rc0 \
+        iotex/iotex-core:v2.5.0-rc1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -131,7 +138,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0-rc0 \
+        iotex/iotex-core:v2.5.0-rc1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -151,7 +158,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0-rc0
+git checkout v2.5.0-rc1
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_CN_testnet.md
+++ b/README_CN_testnet.md
@@ -17,7 +17,7 @@
 
 以下是当前我们使用的软件版本：
 
-- 测试网：v2.5.0
+- 测试网：v2.5.0-rc0
 
 **Note**
 如果你要启动节点加入主网，请点击[**加入主网**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README_CN.md)
@@ -31,7 +31,7 @@
 1. 提取(pull) docker镜像
 
 ```
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.5.0-rc0
 ```
 
 2. 使用以下命令设置运行环境
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. 编辑 `$IOTEX_HOME/etc/config.yaml`, 查找 `externalHost` 和 `producerPrivKey`, 取消注释行并填写您的外部 IP 和私钥。如果`producerPrivKey`放空，你的节点将被分配一个随机密钥。
@@ -100,7 +100,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.5.0-rc0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -118,7 +118,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.5.0-rc0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -138,7 +138,7 @@ docker run -d --restart on-failure --name iotex \
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0
+git checkout v2.5.0-rc0
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -14,6 +14,22 @@
 - [Upgrade Your Node（One Line Upgrader）](#upgrade)
 - [Q&A](#qa)
 
+
+> ### ⚠️ Zanzibar hardfork — TestNet block 46880641 (2026-08-21 ~10:00 CST)
+>
+> Upgrading to `v2.5.0-rc0` **and** re-downloading `genesis_testnet.yaml` is
+> required before that block. A node left on the old binary or the old genesis
+> will fork off the network.
+>
+> The activation height changed from an earlier draft, so re-download the
+> genesis rather than assuming the copy you have is current. `config_testnet.yaml`
+> is unchanged and can be kept.
+>
+> Delegates who want IIP-59 on-chain voter reward distribution need to opt in
+> with `ioctl stake2 voterrewardoptin` and set their reward portions in the
+> DelegateProfile contract. See the
+> [v2.5.0 release note](changelog/v2.5.0-release-note.md).
+
 ## <a name="status"/>Release Status
 
 Here are the software versions we use:

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.4.4
+- TestNet: v2.5.0
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -101,7 +101,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -121,7 +121,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -142,7 +142,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.4.4
+git checkout v2.5.0
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -18,7 +18,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.5.0
+- TestNet: v2.5.0-rc0
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -31,7 +31,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.5.0-rc0
 ```
 
 2. Set the environment with the following commands:
@@ -46,8 +46,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -101,7 +101,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.5.0-rc0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -121,7 +121,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.5.0-rc0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -142,7 +142,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0
+git checkout v2.5.0-rc0
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/README_testnet.md
+++ b/README_testnet.md
@@ -15,15 +15,23 @@
 - [Q&A](#qa)
 
 
-> ### ⚠️ Zanzibar hardfork — TestNet block 46880641 (2026-08-21 ~10:00 CST)
+> ### ⚠️ Zanzibar Beta hardfork — TestNet block 47141281 (2026-08-29 ~06:00 CST)
 >
-> Upgrading to `v2.5.0-rc0` **and** re-downloading `genesis_testnet.yaml` is
+> Upgrading to `v2.5.0-rc1` **and** re-downloading `genesis_testnet.yaml` is
 > required before that block. A node left on the old binary or the old genesis
 > will fork off the network.
 >
-> The activation height changed from an earlier draft, so re-download the
-> genesis rather than assuming the copy you have is current. `config_testnet.yaml`
-> is unchanged and can be kept.
+> **Upgrade the binary first, then the genesis.** A `v2.5.0-rc0` node cannot
+> read the new `genesis_testnet.yaml` at all — it rejects the two keys it does
+> not know (`zanzibarBetaHeight` and `account.testnetGrants`) and refuses to
+> start. Pull `v2.5.0-rc1`, restart, and
+> only then replace the genesis. `config_testnet.yaml` is unchanged and can be
+> kept.
+>
+> Zanzibar itself activated at block 46880641 on 2026-08-21 and is already
+> live. Zanzibar Beta carries three corrections to what Zanzibar turned on, so
+> it needs a height of its own — applying them at Zanzibar's height would
+> re-decide blocks this chain has already committed.
 >
 > Delegates who want IIP-59 on-chain voter reward distribution need to opt in
 > with `ioctl stake2 voterrewardoptin` and set their reward portions in the
@@ -34,7 +42,7 @@
 
 Here are the software versions we use:
 
-- TestNet: v2.5.0-rc0
+- TestNet: v2.5.0-rc1
 
 **Note**
 To start and run a mainnet node, please click [**Join Mainnet**](https://github.com/iotexproject/iotex-bootstrap/blob/master/README.md)
@@ -47,7 +55,7 @@ This is the recommended way to start an IoTeX node
 1. Pull the docker image:
 
 ```
-docker pull iotex/iotex-core:v2.5.0-rc0
+docker pull iotex/iotex-core:v2.5.0-rc1
 ```
 
 2. Set the environment with the following commands:
@@ -62,8 +70,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 ```
 
 3. Edit `$IOTEX_HOME/etc/config.yaml`, look for `externalHost` and `producerPrivKey`, uncomment the lines and fill in your external IP and private key. If you leave `producerPrivKey` empty, your node will be assgined with a random key.
@@ -117,7 +125,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0-rc0 \
+        iotex/iotex-core:v2.5.0-rc1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -137,7 +145,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0-rc0 \
+        iotex/iotex-core:v2.5.0-rc1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -158,7 +166,7 @@ Same as [Join TestNet](#testnet) step 2
 ```
 git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
-git checkout v2.5.0-rc0
+git checkout v2.5.0-rc1
 
 // optional
 export GOPROXY=https://goproxy.io

--- a/archive-node.md
+++ b/archive-node.md
@@ -151,7 +151,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/iotex-archive/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -194,7 +194,7 @@ git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
 
 #checkout the code branch for archive node
-git checkout v2.4.4
+git checkout v2.5.0
 
 #build binary
 make build

--- a/archive-node.md
+++ b/archive-node.md
@@ -151,7 +151,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/iotex-archive/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml \
@@ -194,7 +194,7 @@ git clone https://github.com/iotexproject/iotex-core.git
 cd iotex-core
 
 #checkout the code branch for archive node
-git checkout v2.5.0
+git checkout v2.4.4
 
 #build binary
 make build

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -2,26 +2,39 @@
 
 ## Summary
 
-v2.5.0 is a **required** release for TestNet delegates. It introduces the **Zanzibar** hardfork, which activates IIP-59 on-chain voter reward distribution together with three correctness/security fixes.
+v2.5.0 is a **required** release for both networks. It introduces the **Zanzibar** hardfork, which activates IIP-59 on-chain voter reward distribution.
 
-Zanzibar is scheduled on **TestNet at block 46880641** (2026-08-21, roughly a day after this release). It is **not scheduled on MainNet**.
+| Network | Zanzibar | Beta | Gamma | Approx. date |
+|---|---|---|---|---|
+| TestNet | 46880641 | 47141281 | *not yet scheduled* | activated 2026-08-21 / 08-29 |
+| MainNet | **52813081** | **52813081** | **52813081** | 2026-09-28 ~10:30 CST |
 
-v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46880641 or they will fork off the network.
+**MainNet takes all three at one block.** Beta and Gamma exist to carry corrections to behaviour their predecessor turned on, and splitting them is only forced on a chain that has already committed blocks under the pre-correction behaviour — which is why TestNet had to run Beta 260,640 blocks after Zanzibar. A chain activating them together skips that cost and gets every correction from the first block IIP-59 is live.
 
-Zanzibar has since activated on TestNet as scheduled. `v2.5.0-rc1` follows it with a second fork, **Zanzibar Beta at block 47141281**, carrying three corrections to what Zanzibar turned on plus a TestNet balance grant.
+> **MainNet operators: `genesis_mainnet.yaml` does not change.** MainNet carries its fork heights and the two IIP-59 contract addresses in the binary, not in the genesis file, so there is nothing to re-download. Pull `v2.5.0`, restart. `config_mainnet.yaml` is unchanged too. This is the opposite of the TestNet rollout, where the genesis had to be replaced and the ordering mattered.
 
-`genesis_testnet.yaml` must be refreshed as part of this upgrade — it carries the new activation height and two new contract addresses. `config_testnet.yaml` is unchanged in this release; an existing one can be kept.
+> **TestNet operators: the genesis file *did* change in `rc1`.** Re-download `genesis_testnet.yaml`; keeping the old one forks your node at 47141281. Upgrade the binary **first** — a `v2.5.0-rc0` node cannot parse the new file, rejecting the two keys it does not know (`zanzibarBetaHeight` and `account.testnetGrants`) and refusing to start.
 
-> **TestNet delegates:** the genesis file changed again in `rc1`. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 47141281.
->
-> **Order matters:** upgrade the binary *first*, then replace the genesis. A `v2.5.0-rc0` node cannot parse the new file — it rejects the two keys it does not know (`zanzibarBetaHeight` and `account.testnetGrants`) and refuses to start.
+### What MainNet delegates should do before 52813081
+
+At that block `migrateHermesRewardOptIn` runs **once and never again**. It auto-opts-in every candidate whose reward address is one of the two Hermes vaults — but only if that candidate's DelegateProfile carries both reward-portion fields.
+
+Measured against the live candidate set at block 52,004,121:
+
+| | count | at activation |
+|---|---|---|
+| Hermes vault + complete portions | 88 | migrated onto on-chain distribution |
+| Hermes vault + incomplete portions | 9 | left on the Hermes path |
+| not a vault reward address | 26 | unaffected; opt in with `ioctl stake2 voterrewardoptin` |
+
+Being left on the Hermes path breaks nothing — rewards keep flowing the way they do today — but the delegate does not get on-chain distribution, and there is no second chance at the migration. **If you distribute through Hermes, check that your DelegateProfile has both `blockRewardPortion` and `epochRewardPortion` set before the fork.**
 
 ## Hardfork: Zanzibar
 
 | Network | Height | Approx. date |
 |---------|--------|--------------|
 | TestNet | 46880641 | 2026-08-21 ~10:00 CST |
-| MainNet | not scheduled | — |
+| MainNet | 52813081 | 2026-09-28 ~10:30 CST |
 
 Zanzibar activates six changes at once:
 
@@ -69,7 +82,7 @@ Two IIP-59 parameters are left at their built-in defaults and do not appear in t
 | Network | Height | Approx. date |
 |---------|--------|--------------|
 | TestNet | 47141281 | 2026-08-29 ~06:00 CST |
-| MainNet | not scheduled | — |
+| MainNet | 52813081 | 2026-09-28 ~10:30 CST — same block as Zanzibar |
 
 Zanzibar Beta exists because Zanzibar is already live on TestNet. Three
 corrections to behaviour Zanzibar activated cannot simply be folded into
@@ -116,6 +129,24 @@ part of consensus: a node whose genesis omits it will diverge at 47141281. This
 is a TestNet-only mechanism — `genesis_mainnet.yaml` carries no `testnetGrants`
 and the field is validated to be empty on any chain that is not TestNet.
 
+## Hardfork: Zanzibar Gamma
+
+| Network | Height | Approx. date |
+|---------|--------|--------------|
+| TestNet | *not yet scheduled* | — |
+| MainNet | 52813081 | 2026-09-28 ~10:30 CST — same block as Zanzibar |
+
+Gamma carries four further corrections, gated together:
+
+1. **`ValidateHeaderGasUsed`** — the block header's `gasUsed` is validated rather than trusted.
+2. **`CorrectStakeMigrationGas`** — corrects the gas accounted to a stake migration.
+3. **`CheckedBlockGasDeduction`** — the block gas deduction is checked.
+4. **`RevertStakingStateOnFailedReceipt`** — staking state written before a failure is reverted rather than left behind.
+
+The same equal-height rule applies as for Beta, and there is a concrete cost to letting Gamma trail. `EnforceBLSPoP` rides Zanzibar, and candidate register writes its self-stake bucket *before* it verifies the proof — so on a chain where Gamma trails Zanzibar, a rejected proof leaves that bucket behind until Gamma activates. MainNet avoids that window entirely by taking both at 52813081.
+
+> **TestNet has not scheduled Gamma.** It activated Zanzibar and Beta on builds that predate this fork, so a TestNet node running a build that contains Gamma inherits `MaxUint64` and these four corrections stay off until a height is set for them. That is a follow-up, not part of this release note.
+
 ## Changes
 
 ### Feature
@@ -154,6 +185,28 @@ and the field is validated to be empty on any chain that is not TestNet.
 - `iotex-proto` moves to v0.6.12, which carries the `blsPop` field on `CandidateBasicInfo`.
 
 ## Upgrade
+
+### MainNet
+
+A binary roll. Nothing else changes — the fork heights and both IIP-59 contract
+addresses live in the binary, so `genesis_mainnet.yaml` and
+`config_mainnet.yaml` are both untouched.
+
+```bash
+docker pull iotex/iotex-core:v2.5.0
+# restart your node against the new image
+```
+
+Or non-interactively:
+
+```bash
+bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0
+```
+
+Confirm the node reports `v2.5.0` before block 52813081. There is no genesis
+file to verify, which removes the ordering trap the TestNet rollout had.
+
+### TestNet
 
 The TestNet rollout runs the **`v2.5.0-rc1`** pre-release; `v2.5.0` proper is
 tagged once both forks have been observed on TestNet. Nodes already on `rc0`

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -19,12 +19,13 @@ Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part 
 | TestNet | 46850041 | ~3 days after release |
 | MainNet | not scheduled | — |
 
-Zanzibar activates four changes at once:
+Zanzibar activates five changes at once:
 
 1. **IIP-59 on-chain voter reward distribution** — voter rewards are computed and credited by the protocol at era boundaries instead of by the off-chain Hermes service.
 2. **BLS proof-of-possession at candidate register/update** — closes a rogue-key aggregate-forgery window ahead of IIP-52's signature aggregation.
 3. **In-contract transfer log topic fix.**
 4. **`GetCommittedState` prestate fix** — storage slots absent from the pre-transaction trie no longer report a post-mutation value, correcting EIP-2200 SSTORE gas accounting.
+5. **Blacklist removal** — 13 of the 29 blacklisted accounts stop being treated as blacklisted. No effect on TestNet, whose `config_testnet.yaml` sets an empty `blackList`.
 
 ### New genesis fields
 
@@ -71,6 +72,7 @@ Without both, Zanzibar activates but the voter distribution path has nothing to 
 - **`GetCommittedState` must not return a post-mutation value for prestate-absent keys** (#4869) — the contract-level committed-state cache was populated with post-mutation values for storage slots that did not exist in the pre-transaction trie, so EIP-2200 SSTORE dynamic gas misclassified dirty in-place writes as `SSTORE_RESET` and overcharged 2900 instead of 100 gas per hit. Gated on Zanzibar.
 - **Restore fund-before-sentinel write order in `GrantEpochReward`.**
 - **Rename the voter reward distribution event** (#4969).
+- **Activate the actpool blacklist removal at Zanzibar** (#4861) — the removal list added in #4861 shipped with its height defaulting to "never", so it has not been in effect. It is now driven by the genesis fork height rather than a node-config field: the blacklist predicate is wired into the execution protocol and consulted by the EIP-7702 authorization check, so an operator-settable height was a way for two nodes to validate the same block differently. `blackListRemovalHeight` is no longer read from `config.yaml`.
 
 ### Dependencies
 

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -19,13 +19,14 @@ Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part 
 | TestNet | 46850041 | ~3 days after release |
 | MainNet | not scheduled | — |
 
-Zanzibar activates five changes at once:
+Zanzibar activates six changes at once:
 
 1. **IIP-59 on-chain voter reward distribution** — voter rewards are computed and credited by the protocol at era boundaries instead of by the off-chain Hermes service.
 2. **BLS proof-of-possession at candidate register/update** — closes a rogue-key aggregate-forgery window ahead of IIP-52's signature aggregation.
 3. **In-contract transfer log topic fix.**
 4. **`GetCommittedState` prestate fix** — storage slots absent from the pre-transaction trie no longer report a post-mutation value, correcting EIP-2200 SSTORE gas accounting.
 5. **Blacklist removal** — 13 of the 29 blacklisted accounts stop being treated as blacklisted. No effect on TestNet, whose `config_testnet.yaml` sets an empty `blackList`.
+6. **Candidate BLS key becomes optional** — `candidateRegister` and `candidateUpdate` no longer require `blsPubKey`.
 
 ### New genesis fields
 
@@ -72,6 +73,7 @@ Without both, Zanzibar activates but the voter distribution path has nothing to 
 - **`GetCommittedState` must not return a post-mutation value for prestate-absent keys** (#4869) — the contract-level committed-state cache was populated with post-mutation values for storage slots that did not exist in the pre-transaction trie, so EIP-2200 SSTORE dynamic gas misclassified dirty in-place writes as `SSTORE_RESET` and overcharged 2900 instead of 100 gas per hit. Gated on Zanzibar.
 - **Restore fund-before-sentinel write order in `GrantEpochReward`.**
 - **Rename the voter reward distribution event** (#4969).
+- **Candidate BLS public key is optional from Zanzibar** — Xingu made `blsPubKey` mandatory on candidate register and update. Nothing consumes it until IIP-52 signature aggregation activates, so it is optional again. A registration that supplies a key keeps using the value-carrying `candidateRegisterWithBLSAndPoP` ABI; one that omits it goes back through the legacy `candidateRegister` entry, whose amount travels in the ABI parameter rather than `msg.value`. An update that omits the key leaves any previously registered key untouched. Supplying a key without its proof-of-possession is still rejected — by the handler, as `ErrUnauthorizedOperator` on the receipt.
 - **Activate the actpool blacklist removal at Zanzibar** (#4861) — the removal list added in #4861 shipped with its height defaulting to "never", so it has not been in effect. It is now driven by the genesis fork height rather than a node-config field: the blacklist predicate is wired into the execution protocol and consulted by the EIP-7702 authorization check, so an operator-settable height was a way for two nodes to validate the same block differently. `blackListRemovalHeight` is no longer read from `config.yaml`.
 
 ### Dependencies

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -4,7 +4,9 @@
 
 v2.5.0 is a **required** release for TestNet delegates. It introduces the **Zanzibar** hardfork, which activates IIP-59 on-chain voter reward distribution together with three correctness/security fixes.
 
-Zanzibar is scheduled on **TestNet at block 46850041** (roughly three days after this release). It is **not scheduled on MainNet** — `genesis_mainnet.yaml` carries no `zanzibarHeight`, so MainNet nodes running v2.5.0 behave exactly as they did on v2.4.4. MainNet operators may upgrade at their convenience; TestNet delegates **must** upgrade before block 46850041 or they will fork off the network.
+Zanzibar is scheduled on **TestNet at block 46850041** (roughly three days after this release). It is **not scheduled on MainNet**.
+
+v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46850041 or they will fork off the network.
 
 Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part of this upgrade — the genesis file carries the new activation height and two new contract addresses.
 

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -44,7 +44,13 @@ poll:
 
 Two IIP-59 parameters are left at their built-in defaults and do not appear in the YAML: `epochsPerRewardEra` (24) and `voterBudgetPerBlock` (256).
 
-> A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, meaning its voters receive nothing through the on-chain path. Delegates intending to exercise IIP-59 on TestNet should set those fields before the fork height.
+### TestNet delegates: two things to do before the fork
+
+**1. Opt in.** IIP-59 only distributes for candidates whose `VoterRewardOnchainOptIn` flag is set. At the fork block the protocol auto-opts-in any candidate whose reward address is one of `hermesRewardVaultAddresses` — a convenience for MainNet delegates who route rewards through a Hermes vault. On TestNet, delegates set their reward address to their own address, so **this migration matches nobody** and no candidate is opted in automatically. TestNet delegates who want on-chain distribution must send the new `SetVoterRewardOptIn` staking action themselves.
+
+**2. Set the commission portions.** A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, so its voters receive nothing through the on-chain path.
+
+Without both, Zanzibar activates but the voter distribution path has nothing to pay out. That is a safe state — no rewards are lost, they simply keep flowing through the existing off-chain path — but it also means IIP-59 is not actually being exercised.
 
 ## Changes
 

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -48,11 +48,31 @@ Two IIP-59 parameters are left at their built-in defaults and do not appear in t
 
 ### TestNet delegates: two things to do before the fork
 
-**1. Opt in.** IIP-59 only distributes for candidates whose `VoterRewardOnchainOptIn` flag is set. At the fork block the protocol auto-opts-in any candidate whose reward address is one of `hermesRewardVaultAddresses` — a convenience for MainNet delegates who route rewards through a Hermes vault. On TestNet, delegates set their reward address to their own address, so **this migration matches nobody** and no candidate is opted in automatically. TestNet delegates who want on-chain distribution must send the new `SetVoterRewardOptIn` staking action themselves.
+**1. Opt in.** IIP-59 only distributes for candidates whose `VoterRewardOnchainOptIn` flag is set. At the fork block the protocol auto-opts-in any candidate whose reward address is one of `hermesRewardVaultAddresses`, a convenience for delegates who route rewards through a Hermes vault. Everyone else must send the new `SetVoterRewardOptIn` staking action themselves:
 
-**2. Set the commission portions.** A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, so its voters receive nothing through the on-chain path.
+```bash
+ioctl stake2 voterrewardoptin -s <candidate owner>
+```
+
+**2. Set the commission portions.** A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, so its voters receive nothing through the on-chain path. The profile is keyed by the candidate's identifier address, so the transaction has to be sent from it — sending from the operator address writes a record nothing reads.
 
 Without both, Zanzibar activates but the voter distribution path has nothing to pay out. That is a safe state — no rewards are lost, they simply keep flowing through the existing off-chain path — but it also means IIP-59 is not actually being exercised.
+
+Surveying the 35 TestNet delegates at the time of writing:
+
+| | count |
+|---|---|
+| reward address is a Hermes vault (auto-opted-in at the fork) | 3 |
+| `blockRewardPortion` / `epochRewardPortion` configured | 2 |
+| both, i.e. paying voters with no further action | **1** |
+
+So the fork will activate with essentially nothing to distribute unless delegates act. To check any single delegate:
+
+```bash
+ioctl node reward payout   <delegate>   # opted in?
+ioctl node reward snapshot <delegate>   # commission frozen for the era
+ioctl node reward pending  <delegate>   # pool waiting to be paid
+```
 
 ## Changes
 
@@ -74,7 +94,18 @@ Without both, Zanzibar activates but the voter distribution path has nothing to 
 - **Restore fund-before-sentinel write order in `GrantEpochReward`.**
 - **Rename the voter reward distribution event** (#4969).
 - **Candidate BLS public key is optional from Zanzibar** — Xingu made `blsPubKey` mandatory on candidate register and update. Nothing consumes it until IIP-52 signature aggregation activates, so it is optional again. A registration that supplies a key keeps using the value-carrying `candidateRegisterWithBLSAndPoP` ABI; one that omits it goes back through the legacy `candidateRegister` entry, whose amount travels in the ABI parameter rather than `msg.value`. An update that omits the key leaves any previously registered key untouched. Supplying a key without its proof-of-possession is still rejected — by the handler, as `ErrUnauthorizedOperator` on the receipt.
+- **Correct the SELFDESTRUCT transaction-log amount** (#4910) — `generateSelfDestructTransferLog` stored the mutable `lastAddBalanceAmount` pointer directly into the `IN_CONTRACT_TRANSFER` log. That pointer is rewritten in place by the gas-deposit refund performed right after the EVM returns, so the recorded self-destruct log was retroactively overwritten with the refund amount. Balances, receipts and state roots are unaffected — transaction logs are not part of any root — but anything reconstructing balances from transaction logs (indexers, wallets, exchanges) was misled. Also ships `txlogpatch --correct-amount` to repair already-recorded logs.
+- **Evict the sender when an action panics during minting** (#4921) — a panic in a single pending action unwound past the sender-eviction logic and was only caught by the mint goroutine's top-level recover, so the whole draft was discarded without removing the offending action from the pool and the same action was picked again on every subsequent attempt. Now recovered around the single-action call and routed through normal error handling, turning a run of failed drafts into one lost draft.
+- **Populate block-level `gasUsed` from fetched receipts** (#4937) — `eth_getBlockByNumber` and friends returned `0x0` for historical and archive reads, because the block loaded from the DAO carries no receipts and the aggregate fell back to that empty list.
+- **Retire a drain whose copy-on-write window was superseded** — a drain frozen against a window that a later freeze replaced can never finish, but the cursor was left merely incomplete, so a chunk grant was emitted on every subsequent block and failed identically until the next era boundary. The cursor now reaches a terminal `abandoned` state and emits one `DRAIN_ABANDONED` reward log, so an indexer can tell "gave up" from "still retrying" instead of seeing an unbounded run of failure receipts.
 - **Activate the actpool blacklist removal at Zanzibar** (#4861) — the removal list added in #4861 shipped with its height defaulting to "never", so it has not been in effect. It is now driven by the genesis fork height rather than a node-config field: the blacklist predicate is wired into the execution protocol and consulted by the EIP-7702 authorization check, so an operator-settable height was a way for two nodes to validate the same block differently. `blackListRemovalHeight` is no longer read from `config.yaml`.
+
+### ioctl
+
+- `ioctl stake2 voterrewardoptin` — opt a candidate into on-chain voter reward distribution.
+- `ioctl action voterrewarddestination [ADDR] [--reset]` — route a voter's rewards to another address.
+- `ioctl node reward pending|delegates|distribution|snapshot|payout|destination` — read the IIP-59 state. `snapshot` and `payout` call out the two configurations that silently pay nothing.
+- `ioctl stake2 register --no-bls` — register a candidate without a BLS key, now that the key is optional.
 
 ### Dependencies
 

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -4,19 +4,19 @@
 
 v2.5.0 is a **required** release for TestNet delegates. It introduces the **Zanzibar** hardfork, which activates IIP-59 on-chain voter reward distribution together with three correctness/security fixes.
 
-Zanzibar is scheduled on **TestNet at block 46850041** (roughly three days after this release). It is **not scheduled on MainNet**.
+Zanzibar is scheduled on **TestNet at block 46880641** (2026-08-21, roughly a day after this release). It is **not scheduled on MainNet**.
 
-v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46850041 or they will fork off the network.
+v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46880641 or they will fork off the network.
 
 Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part of this upgrade — the genesis file carries the new activation height and two new contract addresses.
 
-> **TestNet delegates:** the genesis file changed. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 46850041.
+> **TestNet delegates:** the genesis file changed. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 46880641.
 
 ## Hardfork: Zanzibar
 
 | Network | Height | Approx. date |
 |---------|--------|--------------|
-| TestNet | 46850041 | ~3 days after release |
+| TestNet | 46880641 | 2026-08-21 ~10:00 CST |
 | MainNet | not scheduled | — |
 
 Zanzibar activates six changes at once:
@@ -34,7 +34,7 @@ Zanzibar activates six changes at once:
 
 ```yaml
 blockchain:
-  zanzibarHeight: 46850041
+  zanzibarHeight: 46880641
   autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
 poll:
   delegateProfileContractAddress: io16x0lkj99cx9h032p6vkpkxkzgsxzsam5t5sk5s
@@ -113,19 +113,20 @@ ioctl node reward pending  <delegate>   # pool waiting to be paid
 
 ## Upgrade
 
-TestNet:
+The TestNet rollout runs the **`v2.5.0-rc0`** pre-release; `v2.5.0` proper is
+tagged once the fork has been observed on TestNet.
 
 ```bash
 export IOTEX_HOME=$HOME/iotex-var
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-docker pull iotex/iotex-core:v2.5.0
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+docker pull iotex/iotex-core:v2.5.0-rc0
 ```
 
-Then restart your node against the `iotex/iotex-core:v2.5.0` image. Or non-interactively:
+Then restart your node against the `iotex/iotex-core:v2.5.0-rc0` image. Or non-interactively:
 
 ```bash
-bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0
+bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0-rc0
 ```
 
-Confirm the node picked up the new genesis before the fork height — a node still on the old genesis will produce or accept a divergent block at 46850041.
+Confirm the node picked up the new genesis before the fork height — a node still on the old genesis will produce or accept a divergent block at 46880641. The height moved from an earlier draft, so re-download rather than assuming yours is current.

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -8,7 +8,7 @@ Zanzibar is scheduled on **TestNet at block 46880641** (2026-08-21, roughly a da
 
 v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46880641 or they will fork off the network.
 
-Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part of this upgrade — the genesis file carries the new activation height and two new contract addresses.
+`genesis_testnet.yaml` must be refreshed as part of this upgrade — it carries the new activation height and two new contract addresses. `config_testnet.yaml` is unchanged in this release; an existing one can be kept.
 
 > **TestNet delegates:** the genesis file changed. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 46880641.
 
@@ -35,44 +35,30 @@ Zanzibar activates six changes at once:
 ```yaml
 blockchain:
   zanzibarHeight: 46880641
-  autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
+  autoDepositContractAddress: io1pvlpc02xft2va4f38ae2nvgqglcxtfytez75c4
 poll:
-  delegateProfileContractAddress: io16x0lkj99cx9h032p6vkpkxkzgsxzsam5t5sk5s
+  delegateProfileContractAddress: io19l8qpk08rw0jr4vwguyufva9w4t6aq75q2kt90
 ```
 
-`autoDepositContractAddress` is the AutoDepositRegister contract IIP-59 reads per-voter compound preferences from. It was deployed on TestNet for this release at `0x40C578628ef75fe6e83FCD6DCE989f335D884bCE`, installing the same runtime bytecode as the MainNet deployment so the storage layout matches.
+Both contracts were deployed on TestNet for this release by replaying the
+MainNet creation transactions, so each runtime is byte-identical to MainNet's
+— which matters for AutoDepositRegister, whose storage slots IIP-59 reads
+directly — while the constructors still ran, leaving the owner set and
+pause/unpause usable.
 
-`delegateProfileContractAddress` is the existing TestNet DelegateProfile contract (`0xd19ffB48a5C18B77c541D32c1B1ac2440c287774`), from which IIP-59 reads each delegate's voter-take portions when it freezes the era snapshot.
+| | address |
+|---|---|
+| AutoDepositRegister | `io1pvlpc02xft2va4f38ae2nvgqglcxtfytez75c4` / `0x0b3e1C3d464AD4CED5313f72A9b10047f065A48B` |
+| DelegateProfile | `io19l8qpk08rw0jr4vwguyufva9w4t6aq75q2kt90` / `0x2fcE00d9E71B9f21D58e4709c4B3A57557ae83D4` |
+
+`autoDepositContractAddress` is where IIP-59 reads per-voter compound
+preferences from; it is the same contract iotex-hub writes registrations to,
+so a preference set through the hub is the one the protocol acts on.
+`delegateProfileContractAddress` is where it reads each delegate's voter-take
+portions when it freezes the era snapshot; its three reward-portion fields are
+registered against the existing PermyriadVerifier.
 
 Two IIP-59 parameters are left at their built-in defaults and do not appear in the YAML: `epochsPerRewardEra` (24) and `voterBudgetPerBlock` (256).
-
-### TestNet delegates: two things to do before the fork
-
-**1. Opt in.** IIP-59 only distributes for candidates whose `VoterRewardOnchainOptIn` flag is set. At the fork block the protocol auto-opts-in any candidate whose reward address is one of `hermesRewardVaultAddresses`, a convenience for delegates who route rewards through a Hermes vault. Everyone else must send the new `SetVoterRewardOptIn` staking action themselves:
-
-```bash
-ioctl stake2 voterrewardoptin -s <candidate owner>
-```
-
-**2. Set the commission portions.** A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, so its voters receive nothing through the on-chain path. The profile is keyed by the candidate's identifier address, so the transaction has to be sent from it — sending from the operator address writes a record nothing reads.
-
-Without both, Zanzibar activates but the voter distribution path has nothing to pay out. That is a safe state — no rewards are lost, they simply keep flowing through the existing off-chain path — but it also means IIP-59 is not actually being exercised.
-
-Surveying the 35 TestNet delegates at the time of writing:
-
-| | count |
-|---|---|
-| reward address is a Hermes vault (auto-opted-in at the fork) | 3 |
-| `blockRewardPortion` / `epochRewardPortion` configured | 2 |
-| both, i.e. paying voters with no further action | **1** |
-
-So the fork will activate with essentially nothing to distribute unless delegates act. To check any single delegate:
-
-```bash
-ioctl node reward payout   <delegate>   # opted in?
-ioctl node reward snapshot <delegate>   # commission frozen for the era
-ioctl node reward pending  <delegate>   # pool waiting to be paid
-```
 
 ## Changes
 

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -8,9 +8,13 @@ Zanzibar is scheduled on **TestNet at block 46880641** (2026-08-21, roughly a da
 
 v2.5.0 is therefore a **TestNet-only release**: the MainNet docs in this repository deliberately stay on v2.4.4, and MainNet operators should not upgrade yet. TestNet delegates **must** upgrade before block 46880641 or they will fork off the network.
 
+Zanzibar has since activated on TestNet as scheduled. `v2.5.0-rc1` follows it with a second fork, **Zanzibar Beta at block 47141281**, carrying three corrections to what Zanzibar turned on plus a TestNet balance grant.
+
 `genesis_testnet.yaml` must be refreshed as part of this upgrade — it carries the new activation height and two new contract addresses. `config_testnet.yaml` is unchanged in this release; an existing one can be kept.
 
-> **TestNet delegates:** the genesis file changed. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 46880641.
+> **TestNet delegates:** the genesis file changed again in `rc1`. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 47141281.
+>
+> **Order matters:** upgrade the binary *first*, then replace the genesis. A `v2.5.0-rc0` node cannot parse the new file — it rejects the two keys it does not know (`zanzibarBetaHeight` and `account.testnetGrants`) and refuses to start.
 
 ## Hardfork: Zanzibar
 
@@ -60,6 +64,58 @@ registered against the existing PermyriadVerifier.
 
 Two IIP-59 parameters are left at their built-in defaults and do not appear in the YAML: `epochsPerRewardEra` (24) and `voterBudgetPerBlock` (256).
 
+## Hardfork: Zanzibar Beta
+
+| Network | Height | Approx. date |
+|---------|--------|--------------|
+| TestNet | 47141281 | 2026-08-29 ~06:00 CST |
+| MainNet | not scheduled | — |
+
+Zanzibar Beta exists because Zanzibar is already live on TestNet. Three
+corrections to behaviour Zanzibar activated cannot simply be folded into
+Zanzibar's own height — that would rewrite the semantics of blocks TestNet has
+already committed — so they get a height of their own.
+
+1. **Fail closed on non-settleable epoch-settlement faults.** An epoch reward
+   grant that fails for a reason not every node derives from committed state
+   was still settled as a Failure receipt, so one validator could commit "this
+   epoch paid nobody" while the rest committed the full grant — two receipt
+   roots for one block. Only verdicts classified as settleable now keep the
+   receipt; anything else surfaces as an error. The same gate makes the IIP-59
+   auto-deposit bucket lookup fail closed rather than silently routing a voter's
+   reward to the wrong destination.
+2. **Emit era-freeze logs.** The per-candidate poll snapshot taken at an era
+   freeze now emits reward logs, so indexers can observe the frozen set directly
+   instead of inferring it from the payouts that follow.
+3. **Require a DelegateProfile entry for the Hermes opt-in migration.**
+
+> **Correction 3 is inert on TestNet.** The Hermes opt-in migration runs in
+> exactly one block — the one at Zanzibar's height — and never again. TestNet
+> passed that block on 2026-08-21, so the migration has already run unguarded
+> and no later height brings the guard back. It is listed here for completeness
+> and for chains that have not yet activated Zanzibar, which should set
+> `zanzibarBetaHeight` **equal to** `zanzibarHeight` and get all three.
+
+### TestNet balance grant
+
+`rc1` also adds a scheduled balance credit, applied at the Zanzibar Beta height
+to keep TestNet faucets funded:
+
+```yaml
+account:
+  testnetGrants:
+  - height: 47141281
+    recipients:
+    - address: io1ycl9fzdve2l5yqwxywrtpvz2wtwlzfc349r7fc
+      amount: "1000000000000000000000000000"
+```
+
+The grant **adds to** the recipient's existing balance rather than overwriting
+it, and is applied through the state manager like any other credit, so it is
+part of consensus: a node whose genesis omits it will diverge at 47141281. This
+is a TestNet-only mechanism — `genesis_mainnet.yaml` carries no `testnetGrants`
+and the field is validated to be empty on any chain that is not TestNet.
+
 ## Changes
 
 ### Feature
@@ -99,20 +155,35 @@ Two IIP-59 parameters are left at their built-in defaults and do not appear in t
 
 ## Upgrade
 
-The TestNet rollout runs the **`v2.5.0-rc0`** pre-release; `v2.5.0` proper is
-tagged once the fork has been observed on TestNet.
+The TestNet rollout runs the **`v2.5.0-rc1`** pre-release; `v2.5.0` proper is
+tagged once both forks have been observed on TestNet. Nodes already on `rc0`
+still need this upgrade — `rc0` does not know about Zanzibar Beta and will fork
+at 47141281.
 
 ```bash
 export IOTEX_HOME=$HOME/iotex-var
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-docker pull iotex/iotex-core:v2.5.0-rc0
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+docker pull iotex/iotex-core:v2.5.0-rc1
 ```
 
-Then restart your node against the `iotex/iotex-core:v2.5.0-rc0` image. Or non-interactively:
+Then restart your node against the `iotex/iotex-core:v2.5.0-rc1` image. Or non-interactively:
 
 ```bash
-bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0-rc0
+bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0-rc1
 ```
 
-Confirm the node picked up the new genesis before the fork height — a node still on the old genesis will produce or accept a divergent block at 46880641. The height moved from an earlier draft, so re-download rather than assuming yours is current.
+Pull the image and restart **before** replacing the genesis: `rc0` cannot parse
+a genesis containing `zanzibarBetaHeight` or `testnetGrants`, and will fail to
+start if it is swapped in first with:
+
+```
+failed to unmarshal yaml genesis to struct: yaml: unmarshal errors:
+  field testnetGrants not found in type genesis.Account
+  field zanzibarBetaHeight not found in type genesis.Blockchain
+```
+
+Confirm the node picked up the new genesis before the fork height — a node still
+on the old genesis will produce or accept a divergent block at 47141281. Check
+that your `genesis_testnet.yaml` contains both `zanzibarBetaHeight: 47141281`
+and the `account.testnetGrants` entry above.

--- a/changelog/v2.5.0-release-note.md
+++ b/changelog/v2.5.0-release-note.md
@@ -1,0 +1,88 @@
+# v2.5.0 Release Note
+
+## Summary
+
+v2.5.0 is a **required** release for TestNet delegates. It introduces the **Zanzibar** hardfork, which activates IIP-59 on-chain voter reward distribution together with three correctness/security fixes.
+
+Zanzibar is scheduled on **TestNet at block 46850041** (roughly three days after this release). It is **not scheduled on MainNet** — `genesis_mainnet.yaml` carries no `zanzibarHeight`, so MainNet nodes running v2.5.0 behave exactly as they did on v2.4.4. MainNet operators may upgrade at their convenience; TestNet delegates **must** upgrade before block 46850041 or they will fork off the network.
+
+Both `genesis_testnet.yaml` and `config_testnet.yaml` must be refreshed as part of this upgrade — the genesis file carries the new activation height and two new contract addresses.
+
+> **TestNet delegates:** the genesis file changed. Re-download `genesis_testnet.yaml` when you upgrade; keeping the old one will fork your node at 46850041.
+
+## Hardfork: Zanzibar
+
+| Network | Height | Approx. date |
+|---------|--------|--------------|
+| TestNet | 46850041 | ~3 days after release |
+| MainNet | not scheduled | — |
+
+Zanzibar activates four changes at once:
+
+1. **IIP-59 on-chain voter reward distribution** — voter rewards are computed and credited by the protocol at era boundaries instead of by the off-chain Hermes service.
+2. **BLS proof-of-possession at candidate register/update** — closes a rogue-key aggregate-forgery window ahead of IIP-52's signature aggregation.
+3. **In-contract transfer log topic fix.**
+4. **`GetCommittedState` prestate fix** — storage slots absent from the pre-transaction trie no longer report a post-mutation value, correcting EIP-2200 SSTORE gas accounting.
+
+### New genesis fields
+
+`genesis_testnet.yaml` gains three entries:
+
+```yaml
+blockchain:
+  zanzibarHeight: 46850041
+  autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
+poll:
+  delegateProfileContractAddress: io16x0lkj99cx9h032p6vkpkxkzgsxzsam5t5sk5s
+```
+
+`autoDepositContractAddress` is the AutoDepositRegister contract IIP-59 reads per-voter compound preferences from. It was deployed on TestNet for this release at `0x40C578628ef75fe6e83FCD6DCE989f335D884bCE`, installing the same runtime bytecode as the MainNet deployment so the storage layout matches.
+
+`delegateProfileContractAddress` is the existing TestNet DelegateProfile contract (`0xd19ffB48a5C18B77c541D32c1B1ac2440c287774`), from which IIP-59 reads each delegate's voter-take portions when it freezes the era snapshot.
+
+Two IIP-59 parameters are left at their built-in defaults and do not appear in the YAML: `epochsPerRewardEra` (24) and `voterBudgetPerBlock` (256).
+
+> A delegate that has not configured `blockRewardPortion` / `epochRewardPortion` in the DelegateProfile contract is snapshotted at 100% commission, meaning its voters receive nothing through the on-chain path. Delegates intending to exercise IIP-59 on TestNet should set those fields before the fork height.
+
+## Changes
+
+### Feature
+
+- **IIP-59 on-chain voter reward distribution** (#4953) — moves voter reward computation and payout into the protocol. Rewards accrue per delegate and are drained at era boundaries (24 epochs), chunked across blocks with a per-block voter budget so a single block never carries the whole payout. Adds the `SetVoterRewardOptIn` staking action, per-candidate poll snapshots frozen at the era freeze height, an owner-index over contract-staking buckets, and a `DelegateVoterRewardsDistributed` event for off-chain indexers.
+- **Export the distributed-log decoding API** (#4968) — exposes `Unpack`, `ABI`, and `Topic0` from the `distributedlog` package so indexers can decode `DelegateVoterRewardsDistributed` logs without vendoring the ABI.
+- **`-stop-at-height` to cap startup replay** — bounds indexer catch-up at startup, which makes it practical to bring a node up at a specific height for debugging.
+- **Dump the state write queue on a delta-state digest mismatch** — turns an opaque digest mismatch into an actionable diff.
+
+### Security
+
+- **BLS proof-of-possession at candidate register/update** (#4854) — the staking handler previously validated `blsPubKey` only for format and subgroup membership. Without a possession proof, IIP-52's planned `FastAggregateVerify` path is open to a rogue-key attack: a candidate could register `pk_rogue = g^x − Σ(other pubkeys)` and, once aggregation goes live, forge a 2/3+ quorum certificate with a single signature. Requiring the proof **before** aggregation activates closes the window in which un-attested pubkeys could be collected. Adds `ioctl account blssignpop` and threads the proof through `stake2register` / `stake2update`.
+- **Serialize tracer `Stop` against `GetResult`** — the `debug_trace*` timeout watchdog called `tracer.Stop` from its own goroutine while the tracing goroutine called `GetResult`, with no synchronisation on the interruption reason. Fixed on MainNet-affecting code paths as well; no fork gate.
+
+### Fix
+
+- **`GetCommittedState` must not return a post-mutation value for prestate-absent keys** (#4869) — the contract-level committed-state cache was populated with post-mutation values for storage slots that did not exist in the pre-transaction trie, so EIP-2200 SSTORE dynamic gas misclassified dirty in-place writes as `SSTORE_RESET` and overcharged 2900 instead of 100 gas per hit. Gated on Zanzibar.
+- **Restore fund-before-sentinel write order in `GrantEpochReward`.**
+- **Rename the voter reward distribution event** (#4969).
+
+### Dependencies
+
+- `iotex-proto` moves to v0.6.12, which carries the `blsPop` field on `CandidateBasicInfo`.
+
+## Upgrade
+
+TestNet:
+
+```bash
+export IOTEX_HOME=$HOME/iotex-var
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+docker pull iotex/iotex-core:v2.5.0
+```
+
+Then restart your node against the `iotex/iotex-core:v2.5.0` image. Or non-interactively:
+
+```bash
+bash setup_fullnode.sh --auto --home=$IOTEX_HOME --version=v2.5.0
+```
+
+Confirm the node picked up the new genesis before the fork height — a node still on the old genesis will produce or accept a divergent block at 46850041.

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -40,7 +40,7 @@ blockchain:
   xinguBetaHeight: 36826561
   yapHeight: 42819841
   yapBetaHeight: 43361281
-  zanzibarHeight: 46850041
+  zanzibarHeight: 46880641
   autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
   numCandidateDelegates: 36
   numDelegates: 24

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -41,7 +41,7 @@ blockchain:
   yapHeight: 42819841
   yapBetaHeight: 43361281
   zanzibarHeight: 46880641
-  autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
+  autoDepositContractAddress: io1pvlpc02xft2va4f38ae2nvgqglcxtfytez75c4
   numCandidateDelegates: 36
   numDelegates: 24
   numSubEpochs: 15
@@ -68,7 +68,7 @@ poll:
   systemStakingContractV2Height: 26978830
   systemStakingContractV3Address: io1phddfwuj6ht64lkvjyywqjc2e8t5ycez6c69d7
   systemStakingContractV3Height: 31939788
-  delegateProfileContractAddress: io16x0lkj99cx9h032p6vkpkxkzgsxzsam5t5sk5s
+  delegateProfileContractAddress: io19l8qpk08rw0jr4vwguyufva9w4t6aq75q2kt90
 staking:
   withdrawWaitingPeriod: "336h"
 rewarding:

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -40,6 +40,7 @@ blockchain:
   xinguBetaHeight: 36826561
   yapHeight: 42819841
   yapBetaHeight: 43361281
+  zanzibarHeight: 46850041
   numCandidateDelegates: 36
   numDelegates: 24
   numSubEpochs: 15

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -41,6 +41,7 @@ blockchain:
   yapHeight: 42819841
   yapBetaHeight: 43361281
   zanzibarHeight: 46850041
+  autoDepositContractAddress: io1grzhsc5w7a07d6ple4kuaxylxdwcsj7w8r2zuu
   numCandidateDelegates: 36
   numDelegates: 24
   numSubEpochs: 15
@@ -67,6 +68,7 @@ poll:
   systemStakingContractV2Height: 26978830
   systemStakingContractV3Address: io1phddfwuj6ht64lkvjyywqjc2e8t5ycez6c69d7
   systemStakingContractV3Height: 31939788
+  delegateProfileContractAddress: io16x0lkj99cx9h032p6vkpkxkzgsxzsam5t5sk5s
 staking:
   withdrawWaitingPeriod: "336h"
 rewarding:

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -1,4 +1,9 @@
 account:
+  testnetGrants:
+  - height: 47141281
+    recipients:
+    - address: io1ycl9fzdve2l5yqwxywrtpvz2wtwlzfc349r7fc
+      amount: "1000000000000000000000000000"
   initBalances:
     io10t7juxazfteqzjsd6qjk7tkgmngj2tm7n4fvrd: "1000000000000000000000000000"
     io120au9ra0nffdle04jx2g5gccn6gq8qd4fy03l4: "7000000000000000000000000000"
@@ -41,6 +46,7 @@ blockchain:
   yapHeight: 42819841
   yapBetaHeight: 43361281
   zanzibarHeight: 46880641
+  zanzibarBetaHeight: 47141281
   autoDepositContractAddress: io1pvlpc02xft2va4f38ae2nvgqglcxtfytez75c4
   numCandidateDelegates: 36
   numDelegates: 24

--- a/genesis_testnet.yaml
+++ b/genesis_testnet.yaml
@@ -47,6 +47,7 @@ blockchain:
   yapBetaHeight: 43361281
   zanzibarHeight: 46880641
   zanzibarBetaHeight: 47141281
+  zanzibarGammaHeight: 47468161
   autoDepositContractAddress: io1pvlpc02xft2va4f38ae2nvgqglcxtfytez75c4
   numCandidateDelegates: 36
   numDelegates: 24

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
 command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
@@ -32,7 +32,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -40,9 +40,9 @@ docker run -d --restart on-failure --name iotex \
 # --- Optional: gateway / API node only (not needed for a delegate / fullnode) ---
 # If you run this node as a gateway (add `-plugin=gateway` to the docker run above) so it
 # serves API / transaction-log queries, also apply the transaction-log patch shipped with
-# v2.4.4 (see changelog/v2.4.4-release-note.md):
+# v2.5.0 (see changelog/v2.5.0-release-note.md):
 #
-#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 #
 # then add the following to the chain: section of $IOTEX_HOME/etc/config.yaml and restart:
 #

--- a/scripts/all_in_one_mainnet.sh
+++ b/scripts/all_in_one_mainnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.4.4
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,9 +12,9 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_mainnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_mainnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/trie.db.patch > $IOTEX_HOME/data/trie.db.patch
 
 # Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
 command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
@@ -32,7 +32,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.4.4 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml
@@ -40,9 +40,9 @@ docker run -d --restart on-failure --name iotex \
 # --- Optional: gateway / API node only (not needed for a delegate / fullnode) ---
 # If you run this node as a gateway (add `-plugin=gateway` to the docker run above) so it
 # serves API / transaction-log queries, also apply the transaction-log patch shipped with
-# v2.5.0 (see changelog/v2.5.0-release-note.md):
+# v2.4.4 (see changelog/v2.4.4-release-note.md):
 #
-#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
+#   curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/txlog.db.patch > $IOTEX_HOME/data/txlog.db.patch
 #
 # then add the following to the chain: section of $IOTEX_HOME/etc/config.yaml and restart:
 #

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.5.0
+docker pull iotex/iotex-core:v2.5.0-rc0
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
 command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
@@ -31,7 +31,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0 \
+        iotex/iotex-core:v2.5.0-rc0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.4.4
+docker pull iotex/iotex-core:v2.5.0
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.4.4/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
 command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
@@ -31,7 +31,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.4.4 \
+        iotex/iotex-core:v2.5.0 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml

--- a/scripts/all_in_one_testnet.sh
+++ b/scripts/all_in_one_testnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-docker pull iotex/iotex-core:v2.5.0-rc0
+docker pull iotex/iotex-core:v2.5.0-rc1
 
 mkdir -p ~/iotex-var
 cd ~/iotex-var
@@ -12,8 +12,8 @@ mkdir -p $IOTEX_HOME/data
 mkdir -p $IOTEX_HOME/log
 mkdir -p $IOTEX_HOME/etc
 
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
-curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc0/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/config_testnet.yaml > $IOTEX_HOME/etc/config.yaml
+curl https://raw.githubusercontent.com/iotexproject/iotex-bootstrap/v2.5.0-rc1/genesis_testnet.yaml > $IOTEX_HOME/etc/genesis.yaml
 
 # Download core snapshot (for delegate node) — use multi-threaded aria2c for speed, fall back to curl
 command -v aria2c >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y aria2) || true
@@ -31,7 +31,7 @@ docker run -d --restart on-failure --name iotex \
         -v=$IOTEX_HOME/log:/var/log:rw \
         -v=$IOTEX_HOME/etc/config.yaml:/etc/iotex/config_override.yaml:ro \
         -v=$IOTEX_HOME/etc/genesis.yaml:/etc/iotex/genesis.yaml:ro \
-        iotex/iotex-core:v2.5.0-rc0 \
+        iotex/iotex-core:v2.5.0-rc1 \
         iotex-server \
         -config-path=/etc/iotex/config_override.yaml \
         -genesis-path=/etc/iotex/genesis.yaml


### PR DESCRIPTION
## Summary

Prepares the v2.5.0 MainNet release and records the completed TestNet rollout.

### MainNet

Zanzibar, Beta, and Gamma activate together as one MainNet hardfork:

| Network | Activation height | Estimated time |
|---|---:|---|
| MainNet | **53155801** | **2026-10-08 02:00 UTC / 10:00 CST** |

MainNet has not activated any Zanzibar generation yet, so all three internal feature gates use the same height. Operators and exchanges only need to coordinate one hardfork height.

This is a mandatory binary upgrade to `v2.5.0`. MainNet carries the fork heights and both IIP-59 contract addresses in the binary; `genesis_mainnet.yaml` and `config_mainnet.yaml` are unchanged.

Depends on [iotex-core#5009](https://github.com/iotexproject/iotex-core/pull/5009) being merged and tagged as `v2.5.0`.

### TestNet

The staged rollout has completed:

| Fork | Height | Activation time |
|---|---:|---|
| Zanzibar | 46880641 | 2026-08-21 |
| Zanzibar Beta | 47141281 | 2026-08-29 |
| Zanzibar Gamma | 47468161 | 2026-09-07 10:00 UTC |

TestNet operators must use `v2.5.0-rc2` with the current `genesis_testnet.yaml`. Binary-first ordering is required because rc1 cannot parse `zanzibarGammaHeight`.

## Changes

- Updates MainNet delegate documentation and the v2.5.0 release note to height 53155801 and the estimated UTC/CST activation time.
- Updates TestNet documentation and scripts from rc1 to rc2.
- Records the already-activated TestNet Gamma height consistently with `genesis_testnet.yaml`.
- Keeps MainNet genesis and config files unchanged.

## Verification

- MainNet height is on the existing epoch grid: `(53155801 - 51918841) % 1440 == 0`.
- Zanzibar, Beta, and Gamma use the same MainNet height.
- TestNet block 47468161 is confirmed on-chain at 2026-09-07 10:00:40 UTC.
- Documentation is consistent with the new MainNet schedule.

